### PR TITLE
Feature/ij 42 team member index

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -60,7 +60,7 @@ $border-width: 1px;
     text-align: left;
   }
 
-  &.team_member {
+  &.team_members {
     section#staff, section#users {
       td {
         height: 55px;
@@ -74,6 +74,20 @@ $border-width: 1px;
           text-decoration: none;
           color: $white;
           cursor: pointer;
+        }
+      }
+    }
+  }
+
+  &.team_member section#details {
+    .container {
+      max-width: 500px;
+
+      .form-group, .form-floating {
+        margin-bottom: 0.5rem;
+
+        label {
+          color: $black;
         }
       }
     }

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -61,7 +61,7 @@ $border-width: 1px;
   }
 
   &.team_members {
-    section#staff, section#users {
+    section#team_members, section#users {
       td {
         height: 55px;
         line-height: 55px;
@@ -74,20 +74,6 @@ $border-width: 1px;
           text-decoration: none;
           color: $white;
           cursor: pointer;
-        }
-      }
-    }
-  }
-
-  &.team_member section#details {
-    .container {
-      max-width: 500px;
-
-      .form-group, .form-floating {
-        margin-bottom: 0.5rem;
-
-        label {
-          color: $black;
         }
       }
     }

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -59,4 +59,23 @@ $border-width: 1px;
   &.user section.wellbeing .sliders {
     text-align: left;
   }
+
+  &.team_member {
+    section#staff, section#users {
+      td {
+        height: 55px;
+        line-height: 55px;
+        padding: 0;
+
+        a {
+          display: block;
+          width: 100%;
+          height: 100%;
+          text-decoration: none;
+          color: $white;
+          cursor: pointer;
+        }
+      }
+    }
+  }
 }

--- a/app/controllers/team_members/team_members_controller.rb
+++ b/app/controllers/team_members/team_members_controller.rb
@@ -3,6 +3,11 @@ module TeamMembers
   class TeamMembersController < TeamMembersApplicationController
     before_action :require_admin, :set_team_member
 
+    # GET /team_members/:team_member_id
+    def main
+      render template: 'team_members/team_members/main'
+    end
+
     # PUT /team_members/:team_member_id/approve
     def approve_team_member
       respond_to do |format|

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,19 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def get_created_at
+    self.created_at.strftime("%d/%m/%Y %I:%M %p")
+  end
+
+  def last_update
+    self.updated_at.strftime("%d/%m/%Y %I:%M %p")
+  end
+
+  def get_last_sign_in
+    self.last_sign_in_at.present? ? self.last_sign_in_at.strftime("%d/%m/%Y %I:%M %p") : ''
+  end
+
+  def get_current_sign_in
+    self.current_sign_in_at.present? ? self.current_sign_in_at.strftime("%d/%m/%Y %I:%M %p") : ''
+  end
 end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -24,6 +24,18 @@ class TeamMember < ApplicationRecord
     self.last_sign_in_at.present? ? self.last_sign_in_at.strftime("%d/%m/%Y %I:%M %p") : ''
   end
 
+  def get_current_sign_in
+    self.current_sign_in_at.present? ? self.current_sign_in_at.strftime("%d/%m/%Y %I:%M %p") : ''
+  end
+
+  def get_created_at
+    self.created_at.strftime("%d/%m/%Y %I:%M %p")
+  end
+
+  def last_update
+    self.updated_at.strftime("%d/%m/%Y %I:%M %p")
+  end
+
   private
 
   # validations

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -20,6 +20,12 @@ class TeamMember < ApplicationRecord
   has_many :crisis_events, foreign_key: 'closed_by'
   has_many :crisis_notes, foreign_key: :team_member_id
 
+  def get_last_sign_in
+    self.last_sign_in_at.present? ? self.last_sign_in_at.strftime("%d/%m/%Y %I:%M %p") : ''
+  end
+
+  private
+
   # validations
   validates_presence_of :first_name,
                         :last_name,

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -20,22 +20,6 @@ class TeamMember < ApplicationRecord
   has_many :crisis_events, foreign_key: 'closed_by'
   has_many :crisis_notes, foreign_key: :team_member_id
 
-  def get_last_sign_in
-    self.last_sign_in_at.present? ? self.last_sign_in_at.strftime("%d/%m/%Y %I:%M %p") : ''
-  end
-
-  def get_current_sign_in
-    self.current_sign_in_at.present? ? self.current_sign_in_at.strftime("%d/%m/%Y %I:%M %p") : ''
-  end
-
-  def get_created_at
-    self.created_at.strftime("%d/%m/%Y %I:%M %p")
-  end
-
-  def last_update
-    self.updated_at.strftime("%d/%m/%Y %I:%M %p")
-  end
-
   private
 
   # validations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,10 +12,6 @@ class User < ApplicationRecord
 
   has_many :crisis_events, foreign_key: :user_id
 
-  def get_last_sign_in
-    self.last_sign_in_at.present? ? self.last_sign_in_at.strftime("%d/%m/%Y %I:%M %p") : ''
-  end
-
   def get_release_date
     self.release_date.present? ? self.release_date.strftime("%d/%m/%Y") : ''
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,14 @@ class User < ApplicationRecord
 
   has_many :crisis_events, foreign_key: :user_id
 
+  def get_last_sign_in
+    self.last_sign_in_at.present? ? self.last_sign_in_at.strftime("%d/%m/%Y %I:%M %p") : ''
+  end
+
+  def get_release_date
+    self.release_date.present? ? self.release_date.strftime("%d/%m/%Y") : ''
+  end
+
   private
 
   # validations

--- a/app/views/team_members/dashboard/main.html.erb
+++ b/app/views/team_members/dashboard/main.html.erb
@@ -4,17 +4,19 @@
       <h3>Dashboard</h3>
       <div class="container buttons">
         <div class="row">
-          <%= link_to '#team_members', class: 'col d-flex align-items-center btn' do %>
-            <div class="container">
-              <div class="row">
-                <div class="col">
-                  <i class="mb-1 fas fa-users"></i>
+          <% if current_team_member.admin? %>
+            <%= link_to '#team_members', class: 'col d-flex align-items-center btn' do %>
+              <div class="container">
+                <div class="row">
+                  <div class="col">
+                    <i class="mb-1 fas fa-users"></i>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col">Team Members</div>
                 </div>
               </div>
-              <div class="row">
-                <div class="col">Team Members</div>
-              </div>
-            </div>
+            <% end %>
           <% end %>
           <%= link_to '#users', class: 'col d-flex align-items-center btn' do %>
             <div class="container">
@@ -76,71 +78,73 @@
       </div>
     </section>
   <% end %>
-  <section class="row" id="team_members">
-    <div class="col">
-      <h3>Team Members</h3>
-      <table class="table table-dark table-striped align-middle">
-        <thead>
-          <th scope="col">First</th>
-          <th scope="col">Last</th>
-          <th scope="col">Email</th>
-          <th scope="col">Admin</th>
-          <th scope="col">Last Sign In</th>
-        </thead>
-        <tbody>
-          <% @approved_team_members.each do |team_member| %>
-            <tr>
-              <td>
-                <%= link_to team_member_path(team_member) do %>
-                  <%= team_member.first_name %>
-                <% end %>
-              </td>
-              <td>
-                <%= link_to team_member_path(team_member) do %>
-                  <%= team_member.last_name %>
-                <% end %>
-              </td>
-              <td>
-                <%= link_to team_member_path(team_member) do %>
-                  <%= team_member.email %>
-                <% end %>
-              </td>
-              <td>
-                <%= link_to team_member_path(team_member) do %>
-                  <% if current_team_member.admin? and current_team_member.id != team_member.id %>
-                    <%= form_with url: toggle_admin_path(team_member.id), method: :put do |form| %>
-                      <%= form.hidden_field :team_member_id, value: team_member.id %>
-                      <%= button_to '', { action: 'submit', class: 'btn w-100', data: {
-                        confirm: team_member.admin ?
-                                   "Demote #{team_member.first_name} #{team_member.last_name} from an admin role?" :
-                                   "Promote #{team_member.first_name} #{team_member.last_name} to an admin role?" }} do %>
-                        <% if team_member.admin %>
-                          <i class="fas fa-check-circle"></i>
-                        <% else %>
-                          <i class="fas fa-times-circle"></i>
+  <% if current_team_member.admin? %>
+    <section class="row" id="team_members">
+      <div class="col">
+        <h3>Team Members</h3>
+        <table class="table table-dark table-striped align-middle">
+          <thead>
+            <th scope="col">First</th>
+            <th scope="col">Last</th>
+            <th scope="col">Email</th>
+            <th scope="col">Admin</th>
+            <th scope="col">Last Sign In</th>
+          </thead>
+          <tbody>
+            <% @approved_team_members.each do |team_member| %>
+              <tr>
+                <td>
+                  <%= link_to team_member_path(team_member) do %>
+                    <%= team_member.first_name %>
+                  <% end %>
+                </td>
+                <td>
+                  <%= link_to team_member_path(team_member) do %>
+                    <%= team_member.last_name %>
+                  <% end %>
+                </td>
+                <td>
+                  <%= link_to team_member_path(team_member) do %>
+                    <%= team_member.email %>
+                  <% end %>
+                </td>
+                <td>
+                  <%= link_to team_member_path(team_member) do %>
+                    <% if current_team_member.id != team_member.id %>
+                      <%= form_with url: toggle_admin_path(team_member.id), method: :put do |form| %>
+                        <%= form.hidden_field :team_member_id, value: team_member.id %>
+                        <%= button_to '', { action: 'submit', class: 'btn w-100', data: {
+                          confirm: team_member.admin ?
+                                     "Demote #{team_member.first_name} #{team_member.last_name} from an admin role?" :
+                                     "Promote #{team_member.first_name} #{team_member.last_name} to an admin role?" }} do %>
+                          <% if team_member.admin %>
+                            <i class="fas fa-check-circle"></i>
+                          <% else %>
+                            <i class="fas fa-times-circle"></i>
+                          <% end %>
                         <% end %>
                       <% end %>
-                    <% end %>
-                  <% else %>
-                    <% if team_member.admin %>
-                      <i class="fas fa-check-circle"></i>
                     <% else %>
-                      <i class="fas fa-times-circle"></i>
+                      <% if team_member.admin %>
+                        <i class="fas fa-check-circle"></i>
+                      <% else %>
+                        <i class="fas fa-times-circle"></i>
+                      <% end %>
                     <% end %>
                   <% end %>
-                <% end %>
-              </td>
-              <td>
-                <%= link_to team_member_path(team_member) do %>
-                  <%= team_member.get_last_sign_in %>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </section>
+                </td>
+                <td>
+                  <%= link_to team_member_path(team_member) do %>
+                    <%= team_member.get_last_sign_in %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% end %>
   <section class="row" id="users">
     <div class="col">
       <h2 class="mb-3">User</h2>

--- a/app/views/team_members/dashboard/main.html.erb
+++ b/app/views/team_members/dashboard/main.html.erb
@@ -1,4 +1,4 @@
-<main class="container dashboard team_member">
+<main class="container dashboard team_members">
   <section class="row">
     <div class="col mb-3">
       <h2 class="mb-3">Dashboard</h2>

--- a/app/views/team_members/dashboard/main.html.erb
+++ b/app/views/team_members/dashboard/main.html.erb
@@ -62,7 +62,7 @@
               <td><%= team_member.first_name %></td>
               <td><%= team_member.last_name %></td>
               <td><%= team_member.email %></td>
-              <td><%= team_member.last_sign_in_at %></td>
+              <td><%= team_member.get_last_sign_in %></td>
               <td>
                 <%= form_with url: approve_team_member_path(team_member.id), method: :put do |form| %>
                   <%= form.hidden_field :team_member_id, value: team_member.id %>
@@ -116,7 +116,7 @@
                   <% end %>
                 <% end %>
               </td>
-              <td><%= team_member.last_sign_in_at %></td>
+              <td><%= team_member.get_last_sign_in %></td>
             </tr>
           <% end %>
         </tbody>
@@ -132,22 +132,16 @@
           <th scope="col">Last</th>
           <th scope="col">Release Date</th>
           <th scope="col">Email</th>
-          <th scope="col">Last Login</th>
+          <th scope="col">Last Sign In</th>
         </thead>
         <tbody>
           <% @users.each do |user| %>
             <tr>
               <td><%= user.first_name %></td>
               <td><%= user.last_name %></td>
-              <td>
-                <% if user.release_date %>
-                  <%= user.release_date %>
-                <% else %>
-                  Unknown
-                <% end %>
-              </td>
+              <td><%= user.get_release_date %></td>
               <td><%= user.email %></td>
-              <td><%= user.last_sign_in_at %></td>
+              <td><%= user.get_last_sign_in %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/team_members/dashboard/main.html.erb
+++ b/app/views/team_members/dashboard/main.html.erb
@@ -1,4 +1,4 @@
-<main class="container dashboard">
+<main class="container dashboard team_member">
   <section class="row">
     <div class="col mb-3">
       <h2 class="mb-3">Dashboard</h2>
@@ -90,33 +90,51 @@
         <tbody>
           <% @approved_team_members.each do |team_member| %>
             <tr>
-              <td><%= team_member.first_name %></td>
-              <td><%= team_member.last_name %></td>
-              <td><%= team_member.email %></td>
               <td>
-                <% if current_team_member.admin? and current_team_member.id != team_member.id %>
-                  <%= form_with url: toggle_admin_path(team_member.id), method: :put do |form| %>
-                    <%= form.hidden_field :team_member_id, value: team_member.id %>
-                    <%= button_to '', { action: 'submit', class: 'btn w-100', data: {
-                      confirm: team_member.admin ?
-                                 "Demote #{team_member.first_name} #{team_member.last_name} from an admin role?" :
-                                 "Promote #{team_member.first_name} #{team_member.last_name} to an admin role?" }} do %>
-                      <% if team_member.admin %>
-                        <i class="fas fa-check-circle"></i>
-                      <% else %>
-                        <i class="fas fa-times-circle"></i>
+                <%= link_to team_member_path(team_member) do %>
+                  <%= team_member.first_name %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to team_member_path(team_member) do %>
+                  <%= team_member.last_name %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to team_member_path(team_member) do %>
+                  <%= team_member.email %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to team_member_path(team_member) do %>
+                  <% if current_team_member.admin? and current_team_member.id != team_member.id %>
+                    <%= form_with url: toggle_admin_path(team_member.id), method: :put do |form| %>
+                      <%= form.hidden_field :team_member_id, value: team_member.id %>
+                      <%= button_to '', { action: 'submit', class: 'btn w-100', data: {
+                        confirm: team_member.admin ?
+                                   "Demote #{team_member.first_name} #{team_member.last_name} from an admin role?" :
+                                   "Promote #{team_member.first_name} #{team_member.last_name} to an admin role?" }} do %>
+                        <% if team_member.admin %>
+                          <i class="fas fa-check-circle"></i>
+                        <% else %>
+                          <i class="fas fa-times-circle"></i>
+                        <% end %>
                       <% end %>
                     <% end %>
-                  <% end %>
-                <% else %>
-                  <% if team_member.admin %>
-                    <i class="fas fa-check-circle"></i>
                   <% else %>
-                    <i class="fas fa-times-circle"></i>
+                    <% if team_member.admin %>
+                      <i class="fas fa-check-circle"></i>
+                    <% else %>
+                      <i class="fas fa-times-circle"></i>
+                    <% end %>
                   <% end %>
                 <% end %>
               </td>
-              <td><%= team_member.get_last_sign_in %></td>
+              <td>
+                <%= link_to team_member_path(team_member) do %>
+                  <%= team_member.get_last_sign_in %>
+                <% end %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/team_members/dashboard/main.html.erb
+++ b/app/views/team_members/dashboard/main.html.erb
@@ -1,10 +1,10 @@
 <main class="container dashboard team_members">
   <section class="row">
     <div class="col mb-3">
-      <h2 class="mb-3">Dashboard</h2>
+      <h3>Dashboard</h3>
       <div class="container buttons">
         <div class="row">
-          <%= link_to '#staff', class: 'col d-flex align-items-center btn' do %>
+          <%= link_to '#team_members', class: 'col d-flex align-items-center btn' do %>
             <div class="container">
               <div class="row">
                 <div class="col">
@@ -12,7 +12,7 @@
                 </div>
               </div>
               <div class="row">
-                <div class="col">Staff</div>
+                <div class="col">Team Members</div>
               </div>
             </div>
           <% end %>
@@ -47,7 +47,7 @@
   <% if current_team_member.admin? and @unapproved_team_members.count > 0 %>
     <section class="row" id="awaiting_approval">
       <div class="col">
-        <h3>Staff Awaiting Approval</h3>
+        <h3>Team Members Awaiting Approval</h3>
         <table class="table table-dark table-striped align-middle">
           <thead>
             <th scope="col">First</th>
@@ -76,9 +76,9 @@
       </div>
     </section>
   <% end %>
-  <section class="row" id="staff">
+  <section class="row" id="team_members">
     <div class="col">
-      <h3>Staff</h3>
+      <h3>Team Members</h3>
       <table class="table table-dark table-striped align-middle">
         <thead>
           <th scope="col">First</th>
@@ -143,7 +143,7 @@
   </section>
   <section class="row" id="users">
     <div class="col">
-      <h3>User</h3>
+      <h2 class="mb-3">User</h2>
       <table class="table table-dark table-striped">
         <thead>
           <th scope="col">First</th>

--- a/app/views/team_members/team_members/main.html.erb
+++ b/app/views/team_members/team_members/main.html.erb
@@ -1,7 +1,115 @@
-<main class="container dashboard">
-  <section class="row">
+<main class="container dashboard team_member">
+  <section class="row" id="details">
     <div class="col">
-      <h3>This page is for <%= @team_member.email %></h3>
+      <h2 class="mb-3">Team Member Details</h2>
+      <div class="container">
+        <div class="row">
+          <div class="col">
+            <form>
+              <div class="row g-2">
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_first_name" class="form-control" value="<%= @team_member.first_name %>" disabled>
+                    <label for="team_member_first_name">First Name</label>
+                  </div>
+                </div>
+
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_last_name" class="form-control" value="<%= @team_member.last_name %>" disabled>
+                    <label for="team_member_last_name">Last Name</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row g-2">
+                <div class="col-md">
+
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_admin" class="form-control" value="<%= @team_member.admin %>" disabled>
+                    <label for="team_member_admin">Admin</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row g-2">
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_email" class="form-control" value="<%= @team_member.email %>" disabled>
+                    <label for="team_member_email">Email</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row g-2">
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_mobile_number" class="form-control" value="0<%= @team_member.mobile_number %>" disabled>
+                    <label for="team_member_mobile_number">Mobile Number</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row g-2">
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_created_at" class="form-control" value="<%= @team_member.get_created_at %>" disabled>
+                    <label for="team_member_created_at">Created At</label>
+                  </div>
+                </div>
+
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_last_update" class="form-control" value="<%= @team_member.last_update %>" disabled>
+                    <label for="team_member_last_update">Last Update</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row g-2">
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_sign_in_count" class="form-control" value="<%= @team_member.sign_in_count %>" disabled>
+                    <label for="team_member_sign_in_count">Sign In Count</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row g-2">
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_current_sign_in" class="form-control" value="<%= @team_member.get_current_sign_in %>" disabled>
+                    <label for="team_member_current_sign_in">Current Sign In</label>
+                  </div>
+                </div>
+
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_current_sign_in_ip" class="form-control" value="<%= @team_member.current_sign_in_ip %>" disabled>
+                    <label for="team_member_current_sign_in_ip">Current Sign In IP</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row g-2">
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_last_sign_in" class="form-control" value="<%= @team_member.get_last_sign_in %>" disabled>
+                    <label for="team_member_last_sign_in">Last Sign In</label>
+                  </div>
+                </div>
+
+                <div class="col-md">
+                  <div class="form-floating">
+                    <input type="text-field" name="team_member_last_sign_in_ip" class="form-control" value="<%= @team_member.last_sign_in_ip %>" disabled>
+                    <label for="team_member_last_sign_in_ip">Last Sign In IP</label>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 </main>

--- a/app/views/team_members/team_members/main.html.erb
+++ b/app/views/team_members/team_members/main.html.erb
@@ -1,0 +1,7 @@
+<main class="container dashboard">
+  <section class="row">
+    <div class="col">
+      <h3>This page is for <%= @team_member.email %></h3>
+    </div>
+  </section>
+</main>

--- a/app/views/team_members/team_members/main.html.erb
+++ b/app/views/team_members/team_members/main.html.erb
@@ -32,29 +32,31 @@
       </table>
     </div>
   </section>
-  <section class="row">
-    <div class="col">
-      <h3>Team Member Sign In</h3>
-      <table class="table table-dark table-striped">
-        <thead>
-          <th scope="col">Sign In Count</th>
-          <th scope="col">Current Sign In</th>
-          <th scope="col">Current Sign In IP</th>
-          <th scope="col">Last Sign In</th>
-          <th scope="col">Last Sign In IP</th>
-        </thead>
-        <tbody>
-          <tr>
-            <td><%= @team_member.sign_in_count %></td>
-            <td><%= @team_member.get_current_sign_in %></td>
-            <td><%= @team_member.current_sign_in_ip %></td>
-            <td><%= @team_member.get_last_sign_in %></td>
-            <td><%= @team_member.last_sign_in_ip %></td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </section>
+  <% if @team_member.sign_in_count > 0 %>
+    <section class="row">
+      <div class="col">
+        <h3>Team Member Sign In</h3>
+        <table class="table table-dark table-striped">
+          <thead>
+            <th scope="col">Sign In Count</th>
+            <th scope="col">Current Sign In</th>
+            <th scope="col">Current Sign In IP</th>
+            <th scope="col">Last Sign In</th>
+            <th scope="col">Last Sign In IP</th>
+          </thead>
+          <tbody>
+            <tr>
+              <td><%= @team_member.sign_in_count %></td>
+              <td><%= @team_member.get_current_sign_in %></td>
+              <td><%= @team_member.current_sign_in_ip %></td>
+              <td><%= @team_member.get_last_sign_in %></td>
+              <td><%= @team_member.last_sign_in_ip %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% end %>
   <% if @team_member.wba_team_members.count > 0 %>
     <section class="row">
       <div class="col">

--- a/app/views/team_members/team_members/main.html.erb
+++ b/app/views/team_members/team_members/main.html.erb
@@ -1,115 +1,104 @@
 <main class="container dashboard team_member">
-  <section class="row" id="details">
+  <section class="row">
     <div class="col">
-      <h2 class="mb-3">Team Member Details</h2>
-      <div class="container">
-        <div class="row">
-          <div class="col">
-            <form>
-              <div class="row g-2">
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_first_name" class="form-control" value="<%= @team_member.first_name %>" disabled>
-                    <label for="team_member_first_name">First Name</label>
-                  </div>
-                </div>
-
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_last_name" class="form-control" value="<%= @team_member.last_name %>" disabled>
-                    <label for="team_member_last_name">Last Name</label>
-                  </div>
-                </div>
-              </div>
-
-              <div class="row g-2">
-                <div class="col-md">
-
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_admin" class="form-control" value="<%= @team_member.admin %>" disabled>
-                    <label for="team_member_admin">Admin</label>
-                  </div>
-                </div>
-              </div>
-
-              <div class="row g-2">
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_email" class="form-control" value="<%= @team_member.email %>" disabled>
-                    <label for="team_member_email">Email</label>
-                  </div>
-                </div>
-              </div>
-
-              <div class="row g-2">
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_mobile_number" class="form-control" value="0<%= @team_member.mobile_number %>" disabled>
-                    <label for="team_member_mobile_number">Mobile Number</label>
-                  </div>
-                </div>
-              </div>
-
-              <div class="row g-2">
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_created_at" class="form-control" value="<%= @team_member.get_created_at %>" disabled>
-                    <label for="team_member_created_at">Created At</label>
-                  </div>
-                </div>
-
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_last_update" class="form-control" value="<%= @team_member.last_update %>" disabled>
-                    <label for="team_member_last_update">Last Update</label>
-                  </div>
-                </div>
-              </div>
-
-              <div class="row g-2">
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_sign_in_count" class="form-control" value="<%= @team_member.sign_in_count %>" disabled>
-                    <label for="team_member_sign_in_count">Sign In Count</label>
-                  </div>
-                </div>
-              </div>
-
-              <div class="row g-2">
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_current_sign_in" class="form-control" value="<%= @team_member.get_current_sign_in %>" disabled>
-                    <label for="team_member_current_sign_in">Current Sign In</label>
-                  </div>
-                </div>
-
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_current_sign_in_ip" class="form-control" value="<%= @team_member.current_sign_in_ip %>" disabled>
-                    <label for="team_member_current_sign_in_ip">Current Sign In IP</label>
-                  </div>
-                </div>
-              </div>
-
-              <div class="row g-2">
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_last_sign_in" class="form-control" value="<%= @team_member.get_last_sign_in %>" disabled>
-                    <label for="team_member_last_sign_in">Last Sign In</label>
-                  </div>
-                </div>
-
-                <div class="col-md">
-                  <div class="form-floating">
-                    <input type="text-field" name="team_member_last_sign_in_ip" class="form-control" value="<%= @team_member.last_sign_in_ip %>" disabled>
-                    <label for="team_member_last_sign_in_ip">Last Sign In IP</label>
-                  </div>
-                </div>
-              </div>
-            </form>
-          </div>
-        </div>
-      </div>
+      <h3>Team Member Details</h3>
+      <table class="table table-dark table-striped">
+        <thead>
+          <th scope="col">First Name</th>
+          <th scope="col">Last Name</th>
+          <th scope="col">Email</th>
+          <th scope="col">Mobile No.</th>
+          <th scope="col">Admin</th>
+          <th scope="col">Created At</th>
+          <th scope="col">Last Update</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= @team_member.first_name %></td>
+            <td><%= @team_member.last_name %></td>
+            <td><%= @team_member.email %></td>
+            <td>0<%= @team_member.mobile_number %></td>
+            <td>
+              <% if @team_member.admin %>
+                <i class="fas fa-check-circle"></i>
+              <% else %>
+                <i class="fas fa-times-circle"></i>
+              <% end %>
+            </td>
+            <td><%= @team_member.get_created_at %></td>
+            <td><%= @team_member.last_update %></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </section>
+  <section class="row">
+    <div class="col">
+      <h3>Team Member Sign In</h3>
+      <table class="table table-dark table-striped">
+        <thead>
+          <th scope="col">Sign In Count</th>
+          <th scope="col">Current Sign In</th>
+          <th scope="col">Current Sign In IP</th>
+          <th scope="col">Last Sign In</th>
+          <th scope="col">Last Sign In IP</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= @team_member.sign_in_count %></td>
+            <td><%= @team_member.get_current_sign_in %></td>
+            <td><%= @team_member.current_sign_in_ip %></td>
+            <td><%= @team_member.get_last_sign_in %></td>
+            <td><%= @team_member.last_sign_in_ip %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+  <% if @team_member.wba_team_members.count > 0 %>
+    <section class="row">
+      <div class="col">
+        <h3>wellbeing assessments</h3>
+        <table class="table table-dark table-striped">
+          <thead>
+            <th scope="col">User</th>
+            <th scope="col">Created At</th>
+            <th scope="col">Last Update</th>
+          </thead>
+          <tbody>
+            <% @team_member.wba_team_members.order(:created_at).each do |wba_team_member| %>
+              <tr>
+                <td><%= wba_team_member.user.first_name %> <%= wba_team_member.user.last_name %></td>
+                <td><%= wba_team_member.get_created_at %>
+                <td><%= wba_team_member.last_update %>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% end %>
+  <% if @team_member.wba_self_view_logs.count > 0 %>
+    <section class="row">
+      <div class="col">
+        <h3>wellbeing assessment view logs</h3>
+        <table class="table table-dark table-striped">
+          <thead>
+          <th scope="col">User</th>
+          <th scope="col">Created At</th>
+          <th scope="col">Last Update</th>
+          </thead>
+          <tbody>
+          <% @team_member.wba_self_view_logs.order(:created_at).each do |wba_self_view_log| %>
+            <tr>
+              <td><%= wba_self_view_log.wba_self.user.first_name %> <%= wba_self_view_log.wba_self.user.last_name %></td>
+              <td><%= wba_self_view_log.get_created_at %>
+              <td><%= wba_self_view_log.last_update %>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% end %>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   authenticated :team_member do
     root 'team_members/dashboard#main', as: :authenticated_team_member_root
 
+    get '/team_members/:team_member_id', to: 'team_members/team_members#main', as: :team_member
     put '/team_members/:team_member_id/approve', to: 'team_members/team_members#approve_team_member', as: :approve_team_member
     put '/team_members/:team_member_id/admin', to: 'team_members/team_members#toggle_admin', as: :toggle_admin
   end


### PR DESCRIPTION
Admin team members can now drill down into an individual team member to view their details, sign in info and a list of WBA that team member has created as well as the logs for any user created WBA that the team member has viewed.

One enhancement we'll likely want in future is the ability to filter both of these tables by user and date, I could do that as a part of this ticket but for MVP just displaying all the info and using CTRL+F should suffice.

<img width="1440" alt="Screenshot 2021-03-09 at 11 46 02" src="https://user-images.githubusercontent.com/6815945/110470369-ac788880-80d2-11eb-8c96-150a7006f964.png">
