### PR TITLE
Feature/ij 47 sos button

### DIFF
--- a/app/controllers/users/crisis_events_controller.rb
+++ b/app/controllers/users/crisis_events_controller.rb
@@ -4,6 +4,7 @@ module Users
   # app/controllers/users/crisis_events_controller.rb
   class CrisisEventsController < UsersApplicationController
     before_action :crisis_event_params, only: :new
+    after_action :sms, :email, only: :new
 
     # POST /crisis_events/new
     def new
@@ -14,6 +15,24 @@ module Users
       else
         render @crisis_event.errors, status: :unprocessable_entity
       end
+    end
+
+    protected
+
+    def sms
+      puts '=========================================================================================================='
+      puts "CrisisEvent Type: #{@crisis_event.crisis_type.category}"
+      puts "CrisisEvent Additional Info: #{@crisis_event.additional_info}"
+      puts "User: #{current_user.first_name} #{current_user.last_name} 0#{current_user.mobile_number}"
+      puts '=========================================================================================================='
+    end
+
+    def email
+      puts '=========================================================================================================='
+      puts "CrisisEvent Type: #{@crisis_event.crisis_type.category}"
+      puts "CrisisEvent Additional Info: #{@crisis_event.additional_info}"
+      puts "User: #{current_user.first_name} #{current_user.last_name} 0#{current_user.email}"
+      puts '=========================================================================================================='
     end
 
     private

--- a/app/controllers/users/crisis_events_controller.rb
+++ b/app/controllers/users/crisis_events_controller.rb
@@ -31,7 +31,7 @@ module Users
       puts '=========================================================================================================='
       puts "CrisisEvent Type: #{@crisis_event.crisis_type.category}"
       puts "CrisisEvent Additional Info: #{@crisis_event.additional_info}"
-      puts "User: #{current_user.first_name} #{current_user.last_name} 0#{current_user.email}"
+      puts "User: #{current_user.first_name} #{current_user.last_name} #{current_user.email}"
       puts '=========================================================================================================='
     end
 

--- a/app/controllers/users/crisis_events_controller.rb
+++ b/app/controllers/users/crisis_events_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Users
+  # app/controllers/users/crisis_events_controller.rb
+  class CrisisEventsController < UsersApplicationController
+    before_action :crisis_event_params, only: :new
+
+    # POST /crisis_events/new
+    def new
+      if (@crisis_event = current_user.crisis_events.create!(crisis_event_params))
+        respond_to do |format|
+          format.html { redirect_to authenticated_user_root_path, alert: crisis_event_alert }
+        end
+      else
+        render @crisis_event.errors, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def crisis_event_alert
+      'Thank you for reaching out, an Include UK team member will be in touch shortly'
+    end
+
+    def crisis_event_params
+      params.require(:crisis_event).permit(:crisis_type_id, :additional_info)
+    end
+  end
+end

--- a/app/controllers/users/dashboard_controller.rb
+++ b/app/controllers/users/dashboard_controller.rb
@@ -3,16 +3,8 @@
 module Users
   # app/controllers/users/dashboard_controller.rb
   class DashboardController < UsersApplicationController
-    before_action :crisis_event, only: :main
-
     def main
       render template: 'users/dashboard/main'
-    end
-
-    private
-
-    def crisis_event
-      @crisis_event = CrisisEvent.new
     end
   end
 end

--- a/app/controllers/users/dashboard_controller.rb
+++ b/app/controllers/users/dashboard_controller.rb
@@ -1,8 +1,18 @@
+# frozen_string_literal: true
+
 module Users
   # app/controllers/users/dashboard_controller.rb
   class DashboardController < UsersApplicationController
+    before_action :crisis_event, only: :main
+
     def main
       render template: 'users/dashboard/main'
+    end
+
+    private
+
+    def crisis_event
+      @crisis_event = CrisisEvent.new
     end
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,6 +6,7 @@
 import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
+import "bootstrap"
 import "channels"
 require("chartkick")
 require("chart.js")

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,17 +38,51 @@
               <% end %>
             <% end %>
             <% if current_user %>
+              <a class="btn btn-danger m-1" data-bs-toggle="modal" data-bs-target="#sosModal">
+                SOS <i class="fas fa-exclamation-circle"></i>
+              </a>
               <%= link_to edit_user_registration_path, class: "btn btn-success m-1" do %>
                 Edit Profile <i class="fas fa-user-edit"></i>
               <% end %>
               <%= link_to destroy_user_session_path, method: :delete, class: "btn btn-warning m-1" do %>
-                Logout<i class="fas fa-sign-out-alt"></i>
+                Logout <i class="fas fa-sign-out-alt"></i>
               <% end %>
             <% end %>
           </div>
         </div>
       </div>
     </nav>
+
+    <% if current_user %>
+      <div class="modal fade" id="sosModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="sosModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="sosModalLabel">SOS Request</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <p>If you are in need of help please let us know of the situation you are currently dealing with along
+              with any additional information you can share at this time.</p>
+
+              <%= form_with model: @crisis_event do |f| %>
+                <div class="form-floating mb-2">
+                  <%= f.collection_select :crisis_type_id, CrisisType.all, :id, :category, {}, { class: 'form-select' } %>
+                  <%= f.label :crisis_type_id, 'Situation'%>
+                </div>
+
+                <div class="form-floating mb-2">
+                  <%= f.text_area :additional_info, class: 'form-control', style: 'height: 150px' %>
+                  <%= f.label :additional_info, 'Additional Information'%>
+                </div>
+
+                <%= f.submit 'Request Help', class: 'btn btn-primary mt-2' %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 
   <% flash.each do |type, msg| %>
@@ -57,7 +91,7 @@
     </div>
   <% end %>
 
-    <%= yield %>
+  <%= yield %>
 
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,7 +65,7 @@
               <p>If you are in need of help please let us know of the situation you are currently dealing with along
               with any additional information you can share at this time.</p>
 
-              <%= form_with model: @crisis_event do |f| %>
+              <%= form_with model: CrisisEvent.new do |f| %>
                 <div class="form-floating mb-2">
                   <%= f.collection_select :crisis_type_id, CrisisType.all, :id, :category, {}, { class: 'form-select' } %>
                   <%= f.label :crisis_type_id, 'Situation'%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,9 +66,27 @@
               with any additional information you can share at this time.</p>
 
               <%= form_with model: CrisisEvent.new do |f| %>
-                <div class="form-floating mb-2">
-                  <%= f.collection_select :crisis_type_id, CrisisType.all, :id, :category, {}, { class: 'form-select' } %>
-                  <%= f.label :crisis_type_id, 'Situation'%>
+<!--                <div class="form-floating mb-2">-->
+                  <%#= f.collection_select :crisis_type_id, CrisisType.all, :id, :category, {}, { class: 'form-select' } %>
+                  <%#= f.label :crisis_type_id, 'Situation'%>
+<!--                </div>-->
+
+                <div class="row mb-2">
+                  <div class="col-md">
+                    <%= f.collection_radio_buttons :crisis_type_id, CrisisType.all.limit((CrisisType.all.count/2.0).ceil), :id, :category, {} do |b| %>
+                      <div class="form-check">
+                        <%= b.radio_button(class: 'form-check-input') + b.label(class: 'form-check-label') %>
+                      </div>
+                    <% end %>
+                  </div>
+
+                  <div class="col-md">
+                    <%= f.collection_radio_buttons :crisis_type_id, CrisisType.all.offset((CrisisType.all.count/2.0).ceil), :id, :category, {} do |b| %>
+                      <div class="form-check">
+                        <%= b.radio_button(class: 'form-check-input') + b.label(class: 'form-check-label') %>
+                      </div>
+                    <% end %>
+                  </div>
                 </div>
 
                 <div class="form-floating mb-2">
@@ -86,8 +104,9 @@
   <% end %>
 
   <% flash.each do |type, msg| %>
-    <div class="alert <%= alert_class_for(type) %> position-absolute top-0 start-50 translate-middle-x px-5">
+    <div class="alert <%= alert_class_for(type) %> alert-dismissible fade show position-absolute top-0 start-50 translate-middle-x px-5" role="alert">
       <%= msg %>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
 
   authenticated :user do
     root 'users/dashboard#main', as: :authenticated_user_root
+
+    post '/crisis_events/new', to: 'users/crisis_events#new', as: :crisis_events
   end
 
   authenticated :team_member do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -184,28 +184,28 @@ if WbaSelf.count.zero?
 end
 
 CrisisType.create!(
-  category: 'SELF HARM',
+  category: 'Self Harm',
+  team_member_id: 1
+)
+
+CrisisType.create!(
+  category: 'Harming Others',
+  team_member_id: 1
+)
+
+CrisisType.create!(
+  category: 'Suicide',
   team_member_id: 1,
 )
 
 CrisisType.create!(
-  category: 'HARMING OTHERS',
-  team_member_id: 1,
+  category: 'Overdose',
+  team_member_id: 1
 )
 
 CrisisType.create!(
-  category: 'SUICIDE',
-  team_member_id: 1,
-)
-
-CrisisType.create!(
-  category: 'OVER DOSE',
-  team_member_id: 1,
-)
-
-CrisisType.create!(
-  category: 'DOMESTIC VIOLENCE',
-  team_member_id: 1,
+  category: 'Domestic Violence',
+  team_member_id: 1
 )
 
 10.times do

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "include-journey",
   "private": true,
   "dependencies": {
+    "@popperjs/core": "^2.9.1",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",


### PR DESCRIPTION
I've added an SOS button to the header for users that instantiates a modal window wherein the user can enter the type of situation they're dealing with and any additional info they might have. They can then request help given that information from Include UK team members which involves creating a CrisisEvent record along with sending an SMS and email as post actions.

<img width="1440" alt="Screenshot 2021-03-10 at 14 12 47" src="https://user-images.githubusercontent.com/6815945/110642642-1b291500-81ab-11eb-8424-6d942158754f.png">

Currently the sms and email after actions will only print information to the console as this functionality is captured in additional tickets.

![Screenshot 2021-03-10 at 14 12 58](https://user-images.githubusercontent.com/6815945/110642679-2419e680-81ab-11eb-97f8-7ed7669b4233.png)
