### PR TITLE
Feature/ij 57 admin manage crisis

### DIFF
--- a/app/assets/stylesheets/crisis_events.scss
+++ b/app/assets/stylesheets/crisis_events.scss
@@ -15,6 +15,18 @@
           float: right;
         }
       }
+
+      .card-footer {
+        .col-6 {
+          &:first-child {
+            text-align: left;
+          }
+
+          &:last-child {
+            text-align: right;
+          }
+        }
+      }
     }
   }
 

--- a/app/assets/stylesheets/crisis_events.scss
+++ b/app/assets/stylesheets/crisis_events.scss
@@ -1,3 +1,20 @@
 // Place all the styles related to the CrisisEvents controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+@import "variables";
+
+.team_members {
+  &.crisis_event {
+    .card {
+      text-align: left;
+      color: $black;
+
+      .card-header {
+        span:last-child {
+          float: right;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/crisis_events.scss
+++ b/app/assets/stylesheets/crisis_events.scss
@@ -17,4 +17,20 @@
       }
     }
   }
+
+  &.crisis_events {
+    .controls {
+      padding: 0;
+
+      .col {
+        &:first-child {
+          text-align: left;
+        }
+
+        &:last-child {
+          text-align: right;
+        }
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/crisis_events.scss
+++ b/app/assets/stylesheets/crisis_events.scss
@@ -45,4 +45,10 @@
       }
     }
   }
+
+  &.crisis_event, &.crisis_events {
+    .row:first-child {
+      text-align: left;
+    }
+  }
 }

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -15,11 +15,11 @@ $margins: 1rem;
 
   section {
     border-radius: 0.6rem;
-    background-color: $grey;
     text-align: center;
-    margin: 1rem;
+    margin: 1rem 0;
 
-    @media screen and (min-width: $screen-md){
+    @media screen and (min-width: $screen-md) {
+      background-color: $grey;
       margin: 1rem;
       padding: 1rem;
     }
@@ -62,21 +62,9 @@ $margins: 1rem;
       }
     }
 
-    table {
-      td {
-        height: 50px;
-        line-height: 50px;
-        padding: 0;
-
-        a {
-          display: block;
-          width: 100%;
-          height: 100%;
-          text-decoration: none;
-          color: $white;
-          cursor: pointer;
-        }
-      }
+    .table-container {
+      overflow-x: auto;
+      margin-bottom: 0.5rem;
     }
   }
 }

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -3,15 +3,23 @@
 $max-width: 550px;
 $margin: 20px;
 $border-width: 1px;
+$nav-sm: 56px;
 $nav: 62px;
+$footer-sm: 270px;
 $footer: 286px;
 $margins: 1rem;
 
 .team_members, .user {
-  min-height: calc(100vh - #{$nav} - #{$footer} - #{$margins});
+  min-height: calc(100vh - #{$nav-sm} - #{$footer-sm} - #{$margins});
+
+  @media screen and (min-width: $screen-md) {
+    min-height: calc(100vh - #{$nav} - #{$footer} - #{$margins});
+  }
+
   color: $white;
   background-color: $black;
   text-align: center;
+  padding: 0 !important;
 
   section {
     border-radius: 0.6rem;

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -7,7 +7,7 @@ $nav: 62px;
 $footer: 286px;
 $margins: 1rem;
 
-.dashboard, .user {
+.team_members, .user {
   min-height: calc(100vh - #{$nav} - #{$footer} - #{$margins});
   color: $white;
   background-color: $black;

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -30,7 +30,29 @@ body#overboot {
   }
 
   table {
-    border-radius: 0.6rem;
+    white-space: nowrap;
+
+    &.link-table {
+      td {
+        padding: 0 !important;
+      }
+    }
+
+    td {
+      height: 50px;
+      line-height: 50px;
+      padding: 0 1rem;
+
+      a {
+        display: block;
+        width: 100%;
+        height: 100%;
+        text-decoration: none;
+        color: $white;
+        cursor: pointer;
+        padding: 0 1rem;
+      }
+    }
 
     .fa-check-circle {
       color: $success;

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -39,9 +39,12 @@ body#overboot {
     }
 
     td {
+      max-width: 400px;
       height: 50px;
       line-height: 50px;
       padding: 0 1rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
 
       a {
         display: block;
@@ -51,6 +54,8 @@ body#overboot {
         color: $white;
         cursor: pointer;
         padding: 0 1rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     }
 

--- a/app/assets/stylesheets/permissions.scss
+++ b/app/assets/stylesheets/permissions.scss
@@ -17,12 +17,22 @@
     }
   }
 
-  label.btn {
-    color: $white !important;
+  label {
+    background-color: $danger-dark;
+    border-color: $danger-dark;
 
-    i {
-      float: right;
-      line-height: 1.5;
+    &.selected {
+      background-color: $success-dark;
+      border-color: $success-dark;
+    }
+
+    &.btn {
+      color: $white !important;
+
+      i {
+        float: right;
+        line-height: 1.5;
+      }
     }
   }
 

--- a/app/controllers/team_members/crisis_events_controller.rb
+++ b/app/controllers/team_members/crisis_events_controller.rb
@@ -1,0 +1,36 @@
+module TeamMembers
+  # app/controllers/team_members/crisis_events_controller.rb
+  class CrisisEventsController < TeamMembersApplicationController
+    before_action :crisis_events, only: :index
+    before_action :crisis_event, only: %i[show close]
+
+    # GET /crisis_events
+    def index
+      render 'index'
+    end
+
+    # GET /crisis_events/:id
+    def show
+      render 'show'
+    end
+
+    # PUT /crisis_events/:id/close
+    def close
+      if @crisis_event.update({ closed: true, closed_by: current_team_member, closed_at: Time.now })
+        redirect_to crisis_event_path(@crisis_event), alert: 'Crisis event has been closed'
+      else
+        redirect_to crisis_event_path(@crisis_event), alert: 'Crisis event could not be closed'
+      end
+    end
+
+    private
+
+    def crisis_event
+      @crisis_event = CrisisEvent.includes(:user, :crisis_type).find(params[:id])
+    end
+
+    def crisis_events
+      @crisis_events = CrisisEvent.active.includes(:user, :crisis_type).order(:updated_at)
+    end
+  end
+end

--- a/app/controllers/team_members/crisis_events_controller.rb
+++ b/app/controllers/team_members/crisis_events_controller.rb
@@ -3,6 +3,7 @@ module TeamMembers
   class CrisisEventsController < TeamMembersApplicationController
     before_action :crisis_events, only: :index
     before_action :crisis_event, only: %i[show close]
+    before_action :note, :notes, only: :show
 
     # GET /crisis_events
     def index
@@ -30,7 +31,15 @@ module TeamMembers
     end
 
     def crisis_events
-      @crisis_events = CrisisEvent.active.includes(:user, :crisis_type).order(:updated_at)
+      @crisis_events = CrisisEvent.active.includes(:user, :crisis_type).order(updated_at: :desc)
+    end
+
+    def note
+      @note = CrisisNote.new
+    end
+
+    def notes
+      @notes = @crisis_event.crisis_notes.includes(:team_member).order(updated_at: :desc)
     end
   end
 end

--- a/app/controllers/team_members/crisis_events_notes_controller.rb
+++ b/app/controllers/team_members/crisis_events_notes_controller.rb
@@ -1,0 +1,25 @@
+module TeamMembers
+  # app/controllers/team_members/crisis_events_notes_controller.rb
+  class CrisisEventsNotesController < TeamMembersApplicationController
+    before_action :crisis_event, only: %i[new create]
+
+    # POST /crisis_events/:crisis_event_id/crisis_events_notes
+    def create
+      if (@note = CrisisNote.create!({ team_member: current_team_member, crisis_event: @crisis_event, content: crisis_notes_params[:content] }))
+        redirect_to crisis_event_path(@crisis_event), alert: 'Note created'
+      else
+        redirect_to crisis_event_path(@crisis_event), alert: 'Note could not be created'
+      end
+    end
+
+    private
+
+    def crisis_event
+      @crisis_event = CrisisEvent.includes(:user, :crisis_type).find(params[:crisis_event_id])
+    end
+
+    def crisis_notes_params
+      params.require(:crisis_note).permit(:content)
+    end
+  end
+end

--- a/app/controllers/team_members/crisis_events_pages_controller.rb
+++ b/app/controllers/team_members/crisis_events_pages_controller.rb
@@ -19,7 +19,7 @@ module TeamMembers
     end
 
     def crisis_events
-      @crisis_events = CrisisEvent.closed.includes(:user, :crisis_type).offset(@offset).limit(LIMIT).order(:updated_at)
+      @crisis_events = CrisisEvent.closed.includes(:user, :crisis_type).offset(@offset).limit(LIMIT).order(updated_at: :desc)
     end
 
     def last_page

--- a/app/controllers/team_members/crisis_events_pages_controller.rb
+++ b/app/controllers/team_members/crisis_events_pages_controller.rb
@@ -19,7 +19,7 @@ module TeamMembers
     end
 
     def crisis_events
-      @crisis_events = CrisisEvent.closed.includes(:user, :crisis_type).offset(@offset).limit(LIMIT).order(updated_at: :desc)
+      @crisis_events = CrisisEvent.closed.includes(:user, :crisis_type).offset(@offset).limit(LIMIT).order(closed_at: :desc)
     end
 
     def last_page

--- a/app/controllers/team_members/crisis_events_pages_controller.rb
+++ b/app/controllers/team_members/crisis_events_pages_controller.rb
@@ -1,0 +1,45 @@
+module TeamMembers
+  # app/controllers/team_members/crisis_events_pages_controller.rb
+  class CrisisEventsPagesController < TeamMembersApplicationController
+    before_action :page, :offset, :crisis_events, only: :index
+    before_action :count, :last_page, only: :index, if: -> { @crisis_events.present? }
+    before_action :redirect, only: :index, unless: -> { @crisis_events.present? }
+
+    LIMIT = 5
+
+    # GET /crisis_events/page/:page_number
+    def index
+      render 'index'
+    end
+
+    private
+
+    def count
+      @count = CrisisEvent.closed.count
+    end
+
+    def crisis_events
+      @crisis_events = CrisisEvent.closed.includes(:user, :crisis_type).offset(@offset).limit(LIMIT).order(:updated_at)
+    end
+
+    def last_page
+      @last_page = @offset + LIMIT >= @count
+    end
+
+    def offset
+      @offset = (@page - 1) * LIMIT
+    end
+
+    def page
+      @page = params[:page_number].to_i
+
+      return if @page.positive?
+
+      redirect_to authenticated_team_member_root_path, alert: 'Page number cannot be below 1'
+    end
+
+    def redirect
+      redirect_to authenticated_team_member_root_path, alert: 'No crisis events found'
+    end
+  end
+end

--- a/app/controllers/team_members/dashboard_controller.rb
+++ b/app/controllers/team_members/dashboard_controller.rb
@@ -1,25 +1,8 @@
 module TeamMembers
   # app/controllers/team_members/dashboard_controller.rb
   class DashboardController < TeamMembersApplicationController
-    before_action :require_admin, only: :unapproved_team_members
-    before_action :unapproved_team_members, :approved_team_members, :users, only: :show
-
     def show
       render 'show'
-    end
-
-    private
-
-    def unapproved_team_members
-      @unapproved_team_members = TeamMember.unapproved.order(:id)
-    end
-
-    def approved_team_members
-      @approved_team_members = TeamMember.approved.order(:id)
-    end
-
-    def users
-      @users = User.all.order(:id)
     end
   end
 end

--- a/app/controllers/team_members/team_members_application_controller.rb
+++ b/app/controllers/team_members/team_members_application_controller.rb
@@ -7,19 +7,16 @@ module TeamMembers
     protected
 
     def require_approval
-      if current_team_member.present? && !current_team_member.approved?
-        sign_out_and_redirect(current_team_member)
-        session[:awaiting_approval_notice] = 'An admin needs to approve you before you can access the system!'
-      end
+      return if current_team_member.approved?
+
+      sign_out_and_redirect(current_team_member)
+      session[:awaiting_approval_notice] = 'An admin needs to approve you before you can access the system!'
     end
 
     def require_admin
-      unless current_team_member.admin?
-        respond_to do |format|
-          format.html { redirect_to authenticated_team_member_root_path, error: 'You are not an admin!' }
-          format.json { render json: '', status: :forbidden }
-        end
-      end
+      return if current_team_member.admin?
+
+      redirect_to authenticated_team_member_root_path, error: 'You are not an admin!'
     end
   end
 end

--- a/app/controllers/team_members/team_members_controller.rb
+++ b/app/controllers/team_members/team_members_controller.rb
@@ -17,7 +17,6 @@ module TeamMembers
 
     # PUT /team_members/:id/approve
     def approve_team_member
-      debugger
       if @team_member.update(approved: true)
         redirect_to team_members_path, alert: "#{@team_member.first_name} has been approved"
       else

--- a/app/controllers/team_members/team_members_controller.rb
+++ b/app/controllers/team_members/team_members_controller.rb
@@ -17,19 +17,20 @@ module TeamMembers
 
     # PUT /team_members/:id/approve
     def approve_team_member
+      debugger
       if @team_member.update(approved: true)
-        redirect_to authenticated_team_member_root_path, alert: "#{@team_member.first_name} has been approved"
+        redirect_to team_members_path, alert: "#{@team_member.first_name} has been approved"
       else
-        redirect_to authenticated_team_member_root_path, warning: "#{@team_member.first_name} could not be approved"
+        redirect_to team_members_path, warning: "#{@team_member.first_name} could not be approved"
       end
     end
 
     # PUT /team_members/:id/admin
     def toggle_admin
       if @team_member.update(admin: !@team_member.admin?)
-        redirect_to authenticated_team_member_root_path, alert: admin_alert
+        redirect_to team_members_path, alert: admin_alert
       else
-        redirect_to authenticated_team_member_root_path, warning: "#{@team_member.first_name} admin status could not be changed"
+        redirect_to team_members_path, warning: "#{@team_member.first_name} admin status could not be changed"
       end
     end
 
@@ -40,7 +41,7 @@ module TeamMembers
     end
 
     def approved_team_members
-      @approved_team_members = TeamMember.approved.order(:id)
+      @approved_team_members = TeamMember.approved.order(created_at: :desc)
     end
 
     def team_member
@@ -48,7 +49,7 @@ module TeamMembers
     end
 
     def unapproved_team_members
-      @unapproved_team_members = TeamMember.unapproved.order(:id)
+      @unapproved_team_members = TeamMember.unapproved.order(created_at: :desc)
     end
   end
 end

--- a/app/controllers/team_members/team_members_controller.rb
+++ b/app/controllers/team_members/team_members_controller.rb
@@ -41,7 +41,7 @@ module TeamMembers
     end
 
     def approved_team_members
-      @approved_team_members = TeamMember.approved.order(created_at: :desc)
+      @approved_team_members = TeamMember.approved.order(:created_at)
     end
 
     def team_member

--- a/app/controllers/team_members/team_members_controller.rb
+++ b/app/controllers/team_members/team_members_controller.rb
@@ -1,32 +1,35 @@
 module TeamMembers
   # app/controllers/team_members/team_members_controller.rb
   class TeamMembersController < TeamMembersApplicationController
-    before_action :require_admin, :team_member
+    before_action :require_admin
+    before_action :team_member, only: %i[show approve_team_member toggle_admin]
+    before_action :unapproved_team_members, :approved_team_members, only: :index
+
+    # GET /team_members
+    def index
+      render 'index'
+    end
 
     # GET /team_members/:id
     def show
-      render template: 'team_members/team_members/show'
+      render 'show'
     end
 
     # PUT /team_members/:id/approve
     def approve_team_member
-      respond_to do |format|
-        if @team_member.update(approved: true)
-          format.html { redirect_to authenticated_team_member_root_path, alert: "#{@team_member.first_name} has been approved" }
-        else
-          format.html { redirect_to authenticated_team_member_root_path, warning: "#{@team_member.first_name} could not be approved" }
-        end
+      if @team_member.update(approved: true)
+        redirect_to authenticated_team_member_root_path, alert: "#{@team_member.first_name} has been approved"
+      else
+        redirect_to authenticated_team_member_root_path, warning: "#{@team_member.first_name} could not be approved"
       end
     end
 
     # PUT /team_members/:id/admin
     def toggle_admin
-      respond_to do |format|
-        if @team_member.update(admin: !@team_member.admin?)
-          format.html { redirect_to authenticated_team_member_root_path, alert: admin_alert }
-        else
-          format.html { redirect_to authenticated_team_member_root_path, warning: "#{@team_member.first_name} admin status could not be changed" }
-        end
+      if @team_member.update(admin: !@team_member.admin?)
+        redirect_to authenticated_team_member_root_path, alert: admin_alert
+      else
+        redirect_to authenticated_team_member_root_path, warning: "#{@team_member.first_name} admin status could not be changed"
       end
     end
 
@@ -36,8 +39,16 @@ module TeamMembers
       @team_member.admin? ? "#{@team_member.first_name} is now an admin" : "#{@team_member.first_name} is no longer an admin"
     end
 
+    def approved_team_members
+      @approved_team_members = TeamMember.approved.order(:id)
+    end
+
     def team_member
       @team_member = TeamMember.find(params[:id])
+    end
+
+    def unapproved_team_members
+      @unapproved_team_members = TeamMember.unapproved.order(:id)
     end
   end
 end

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -21,7 +21,7 @@ module TeamMembers
     end
 
     def users
-      @users = User.all.order(:id)
+      @users = User.all.order(created_at: :desc)
     end
   end
 end

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -1,16 +1,27 @@
 module TeamMembers
   # app/controllers/team_members/users_controller.rb
   class UsersController < TeamMembersApplicationController
-    before_action :set_user
+    before_action :user, only: :show
+    before_action :users, only: :index
 
+    # GET /users
+    def index
+      render 'index'
+    end
+
+    # GET /users/:id
     def show
       redirect_to authenticated_team_member_root_path, alert: "#{@user.first_name} #{@user.last_name} clicked!"
     end
 
     private
 
-    def set_user
+    def user
       @user = User.find(params[:id])
+    end
+
+    def users
+      @users = User.all.order(:id)
     end
   end
 end

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -11,7 +11,7 @@ module TeamMembers
 
     # GET /users/:id
     def show
-      redirect_to users_path, alert: "#{@user.first_name} #{@user.last_name} clicked!"
+      redirect_back(fallback_location: authenticated_team_member_root_path, alert: "#{@user.first_name} #{@user.last_name} clicked!")
     end
 
     private

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -11,7 +11,7 @@ module TeamMembers
 
     # GET /users/:id
     def show
-      redirect_to authenticated_team_member_root_path, alert: "#{@user.first_name} #{@user.last_name} clicked!"
+      redirect_to users_path, alert: "#{@user.first_name} #{@user.last_name} clicked!"
     end
 
     private

--- a/app/controllers/team_members/wba_team_members_controller.rb
+++ b/app/controllers/team_members/wba_team_members_controller.rb
@@ -5,7 +5,7 @@ module TeamMembers
 
     # GET /team_members/:team_member_id/wba/:wba_team_member_id
     def show
-      redirect_to authenticated_team_member_root_path,
+      redirect_to team_member_path(@team_member),
                   alert: "WBA for #{@wba.user.first_name} #{@wba.user.last_name} created by #{@team_member.first_name} #{@team_member.last_name} clicked!"
     end
 

--- a/app/controllers/users/journal_entries_pages_controller.rb
+++ b/app/controllers/users/journal_entries_pages_controller.rb
@@ -2,7 +2,7 @@ module Users
   # app/controllers/users/journal_entries_controller.rb
   class JournalEntriesPagesController < UsersApplicationController
     before_action :page, :offset, :journal_entries, only: :index
-    before_action :count, only: :index, if: -> { @journal_entries.present? }
+    before_action :count, :last_page, only: :index, if: -> { @journal_entries.present? }
     before_action :redirect, only: :index, unless: -> { @journal_entries.present? }
 
     LIMIT = 3
@@ -12,12 +12,6 @@ module Users
       render 'users/journal_entries/index'
     end
 
-    def last_page
-      @offset + LIMIT >= @count
-    end
-
-    helper_method :last_page
-
     private
 
     def count
@@ -26,6 +20,10 @@ module Users
 
     def journal_entries
       @journal_entries = current_user.journal_entries.offset(@offset).limit(LIMIT).order(created_at: :desc)
+    end
+
+    def last_page
+      @last_page = @offset + LIMIT >= @count
     end
 
     def offset

--- a/app/controllers/users/journal_entry_permissions_controller.rb
+++ b/app/controllers/users/journal_entry_permissions_controller.rb
@@ -11,12 +11,12 @@ module Users
     # POST /journal_entries/:journal_entry_id/journal_entry_permissions/create
     def create
       @team_members.each do |team_member|
-        next unless permissions_params["team_member_#{team_member.id}"] == '1'
+        next if permissions_params["team_member_#{team_member.id}"].to_i.zero?
 
-        JournalEntryPermission.create!({ journal_entry_id: @model.id, team_member_id: team_member.id })
+        JournalEntryPermission.create!({ journal_entry: @model, team_member: team_member })
       end
 
-      redirect_to authenticated_user_root_path, alert: 'Sharing permissions for team members successfully set'
+      redirect_to pages_journal_entries_path(1), alert: 'Sharing permissions for team members successfully set'
     end
 
     protected

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -44,7 +44,7 @@ module Users
     end
 
     def team_members
-      @team_members = TeamMember.all
+      @team_members = TeamMember.all.order(:created_at)
     end
 
     def at_least_one

--- a/app/controllers/users/wba_self_permissions_controller.rb
+++ b/app/controllers/users/wba_self_permissions_controller.rb
@@ -11,12 +11,12 @@ module Users
     # POST /wba_selves/:wba_self_id/wba_self_permissions/create
     def create
       @team_members.each do |team_member|
-        next unless permissions_params["team_member_#{team_member.id}"] == '1'
+        next if permissions_params["team_member_#{team_member.id}"].to_i.zero?
 
-        WbaSelfPermission.create!({ wba_self_id: @model.id, team_member_id: team_member.id })
+        WbaSelfPermission.create!({ wba_self: @model, team_member: team_member })
       end
 
-      redirect_to authenticated_user_root_path, alert: 'Sharing permissions for team members successfully set'
+      redirect_to wba_self_path(@model), alert: 'Sharing permissions for team members successfully set'
     end
 
     protected

--- a/app/javascript/packs/permissions.js
+++ b/app/javascript/packs/permissions.js
@@ -4,20 +4,11 @@ function toggle(checkbox) {
     const label = checkbox.closest('div').querySelector('label'),
           icon = checkbox.closest('div').querySelector('i')
 
-    if (checkbox.checked) {
-        label.style['background-color'] = '#70A739'
-        label.style['border-color'] = '#70A739'
-        icon.classList.add('fa-check-circle')
-        icon.classList.remove('fa-times-circle')
-    } else {
-        label.style['background-color'] = '#F32516'
-        label.style['border-color'] = '#F32516'
-        icon.classList.remove('fa-check-circle')
-        icon.classList.add('fa-times-circle')
-    }
+    label.classList.toggle('selected')
+    icon.classList.toggle('fa-check-circle')
+    icon.classList.toggle('fa-times-circle')
 }
 
 checkboxes.forEach(checkbox => {
     checkbox.addEventListener('change', () => toggle(checkbox))
-    toggle(checkbox)
 })

--- a/app/models/crisis_event.rb
+++ b/app/models/crisis_event.rb
@@ -4,4 +4,7 @@ class CrisisEvent < ApplicationRecord
   belongs_to :crisis_type
   belongs_to :closed_by, class_name: 'TeamMember', optional: true
   has_many :crisis_notes, foreign_key: :crisis_event_id
+
+  scope :active, -> { where(closed: false) }
+  scope :closed, -> { where(closed: true) }
 end

--- a/app/models/crisis_event.rb
+++ b/app/models/crisis_event.rb
@@ -7,4 +7,8 @@ class CrisisEvent < ApplicationRecord
 
   scope :active, -> { where(closed: false) }
   scope :closed, -> { where(closed: true) }
+
+  def closed_formatted
+    closed_at.strftime('%d/%m/%Y %I:%M %p')
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,7 +73,7 @@
 
   <%= yield %>
 
-  <% if user_signed_in? %>
+  <% if user_signed_in? || team_member_signed_in? %>
     <footer class="text-center text-white bg-brand">
       <div class="footers container pt-4">
         <a class="title" href="https://include-uk.com"><h3> Include uk</h3></a>

--- a/app/views/team_members/crisis_events/index.html.erb
+++ b/app/views/team_members/crisis_events/index.html.erb
@@ -2,33 +2,38 @@
   <section class="row">
     <div class="col">
       <h3>Active Crisis Events</h3>
-      <table class="table table-dark table-striped">
-        <thead>
-          <th scope="col">User</th>
-          <th scope="col">Crisis Type</th>
-          <th scope="col">Additional Info</th>
-          <th scope="col">Last Update</th>
-        </thead>
-        <tbody>
-          <% @crisis_events.each do |crisis_event| %>
-            <tr>
-              <td>
-                <%= link_to "#{crisis_event.user.first_name} #{crisis_event.user.last_name}",
-                            crisis_event_path(crisis_event) %>
-              </td>
-              <td>
-                <%= link_to "#{crisis_event.crisis_type.category}", crisis_event_path(crisis_event) %>
-              </td>
-              <td>
-                <%= link_to "#{crisis_event.additional_info}", crisis_event_path(crisis_event) %>
-              </td>
-              <td>
-                <%= link_to "#{crisis_event.last_update}", crisis_event_path(crisis_event) %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+      <% if @crisis_events.count > 0 %>
+        <table class="table table-dark table-striped">
+          <thead>
+            <th scope="col">User</th>
+            <th scope="col">Crisis Type</th>
+            <th scope="col">Additional Info</th>
+            <th scope="col">Last Update</th>
+          </thead>
+          <tbody>
+            <% @crisis_events.each do |crisis_event| %>
+              <tr>
+                <td>
+                  <%= link_to "#{crisis_event.user.first_name} #{crisis_event.user.last_name}",
+                              crisis_event_path(crisis_event) %>
+                </td>
+                <td>
+                  <%= link_to "#{crisis_event.crisis_type.category}", crisis_event_path(crisis_event) %>
+                </td>
+                <td>
+                  <%= link_to "#{crisis_event.additional_info}", crisis_event_path(crisis_event) %>
+                </td>
+                <td>
+                  <%= link_to "#{crisis_event.last_update}", crisis_event_path(crisis_event) %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <h3>No active crisis events</h3>
+      <% end %>
+      <%= link_to 'View Closed', pages_crisis_events_path(1), class: 'btn btn-primary' %>
     </div>
   </section>
 </main>

--- a/app/views/team_members/crisis_events/index.html.erb
+++ b/app/views/team_members/crisis_events/index.html.erb
@@ -3,33 +3,35 @@
     <div class="col">
       <h3>Active Crisis Events</h3>
       <% if @crisis_events.count > 0 %>
-        <table class="table table-dark table-striped">
-          <thead>
-            <th scope="col">User</th>
-            <th scope="col">Crisis Type</th>
-            <th scope="col">Additional Info</th>
-            <th scope="col">Last Update</th>
-          </thead>
-          <tbody>
-            <% @crisis_events.each do |crisis_event| %>
-              <tr>
-                <td>
-                  <%= link_to "#{crisis_event.user.first_name} #{crisis_event.user.last_name}",
-                              crisis_event_path(crisis_event) %>
-                </td>
-                <td>
-                  <%= link_to "#{crisis_event.crisis_type.category}", crisis_event_path(crisis_event) %>
-                </td>
-                <td>
-                  <%= link_to "#{crisis_event.additional_info}", crisis_event_path(crisis_event) %>
-                </td>
-                <td>
-                  <%= link_to "#{crisis_event.last_update}", crisis_event_path(crisis_event) %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+        <div class="table-container">
+          <table class="table table-dark table-striped link-table">
+            <thead>
+              <th scope="col">User</th>
+              <th scope="col">Crisis Type</th>
+              <th scope="col">Additional Info</th>
+              <th scope="col">Last Update</th>
+            </thead>
+            <tbody>
+              <% @crisis_events.each do |crisis_event| %>
+                <tr>
+                  <td>
+                    <%= link_to "#{crisis_event.user.first_name} #{crisis_event.user.last_name}",
+                                crisis_event_path(crisis_event) %>
+                  </td>
+                  <td>
+                    <%= link_to "#{crisis_event.crisis_type.category}", crisis_event_path(crisis_event) %>
+                  </td>
+                  <td>
+                    <%= link_to "#{crisis_event.additional_info}", crisis_event_path(crisis_event) %>
+                  </td>
+                  <td>
+                    <%= link_to "#{crisis_event.last_update}", crisis_event_path(crisis_event) %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
       <% else %>
         <h3>No active crisis events</h3>
       <% end %>

--- a/app/views/team_members/crisis_events/index.html.erb
+++ b/app/views/team_members/crisis_events/index.html.erb
@@ -1,0 +1,34 @@
+<main class="container team_members">
+  <section class="row">
+    <div class="col">
+      <h3>Active Crisis Events</h3>
+      <table class="table table-dark table-striped">
+        <thead>
+          <th scope="col">User</th>
+          <th scope="col">Crisis Type</th>
+          <th scope="col">Additional Info</th>
+          <th scope="col">Last Update</th>
+        </thead>
+        <tbody>
+          <% @crisis_events.each do |crisis_event| %>
+            <tr>
+              <td>
+                <%= link_to "#{crisis_event.user.first_name} #{crisis_event.user.last_name}",
+                            crisis_event_path(crisis_event) %>
+              </td>
+              <td>
+                <%= link_to "#{crisis_event.crisis_type.category}", crisis_event_path(crisis_event) %>
+              </td>
+              <td>
+                <%= link_to "#{crisis_event.additional_info}", crisis_event_path(crisis_event) %>
+              </td>
+              <td>
+                <%= link_to "#{crisis_event.last_update}", crisis_event_path(crisis_event) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</main>

--- a/app/views/team_members/crisis_events/show.html.erb
+++ b/app/views/team_members/crisis_events/show.html.erb
@@ -1,8 +1,8 @@
 <main class="container team_members crisis_event">
   <div class="row m-1 mt-3">
     <div class="col">
-      <%= link_to :back, class: 'btn btn-primary' do %>
-        <i class="fas fa-arrow-circle-left"></i> Back
+      <%= link_to crisis_events_path, class: 'btn btn-primary' do %>
+        <i class="fas fa-arrow-circle-left"></i> Active crisis events
       <% end %>
     </div>
   </div>
@@ -74,7 +74,7 @@
                     <span><%= note.last_update %> </span>
                   </div>
                   <div class="card-body">
-                    <p class="card-text"><%= note.content %></p>
+                    <p class="card-text"><%= simple_format(note.content) %></p>
                   </div>
                 </div>
               </div>

--- a/app/views/team_members/crisis_events/show.html.erb
+++ b/app/views/team_members/crisis_events/show.html.erb
@@ -10,8 +10,14 @@
     <div class="col-lg-3"></div>
     <div class="col-lg-6">
       <h3 class="mb-3">Crisis Event</h3>
-      <h5 class="mb-3"><u><%= @crisis_event.user.first_name %> <%= @crisis_event.user.last_name %></u>
-        raised an SOS <u><%= time_ago_in_words(@crisis_event.created_at) %> ago</u></h5>
+      <h5 class="mb-3"><%= @crisis_event.user.first_name %> <%= @crisis_event.user.last_name %>
+        raised an SOS <%= time_ago_in_words(@crisis_event.created_at) %> ago</h5>
+      <% unless @crisis_event.closed %>
+        <h5 class="mb-3">
+          Mobile Number: <a href="tel:0<%= @crisis_event.user.mobile_number %>">0<%= @crisis_event.user.mobile_number %></a>
+        </h5>
+      <% end %>
+
       <div class="card mb-3">
         <div class="card-header">
           <% if @crisis_event.closed %>
@@ -24,7 +30,6 @@
         </div>
         <div class="card-body">
           <h5 class="card-title mb-3">Crisis Type: <%= @crisis_event.crisis_type.category %></h5>
-
           <p class="card-text">
             <% if @crisis_event.additional_info.empty? %>
               User has not provided any additional info

--- a/app/views/team_members/crisis_events/show.html.erb
+++ b/app/views/team_members/crisis_events/show.html.erb
@@ -1,33 +1,50 @@
 <main class="container team_members crisis_event">
+  <div class="row m-1 mt-3">
+    <div class="col">
+      <%= link_to :back, class: 'btn btn-primary' do %>
+        <i class="fas fa-arrow-circle-left"></i> Back
+      <% end %>
+    </div>
+  </div>
   <section class="row">
     <div class="col-lg-3"></div>
     <div class="col-lg-6">
-      <h3 class="mb-3">Crisis Event - <%= @crisis_event.user.first_name %> <%= @crisis_event.user.last_name %></h3>
+      <h3 class="mb-3">Crisis Event</h3>
+      <h5 class="mb-3"><u><%= @crisis_event.user.first_name %> <%= @crisis_event.user.last_name %></u>
+        raised an SOS <u><%= time_ago_in_words(@crisis_event.created_at) %> ago</u></h5>
       <div class="card mb-3">
         <div class="card-header">
-          <span>
-            <% if @crisis_event.closed %>
-              <strong>Closed</strong> <i class="fas fa-times-circle"></i>
-            <% else %>
-              <strong>Active</strong> <i class="fas fa-exclamation-circle"></i>
-            <% end %>
-          </span>
-          <span><%= @crisis_event.last_update %></span>
+          <% if @crisis_event.closed %>
+            <span><strong>Closed</strong> <i class="fas fa-times-circle"></i></span>
+            <span><strong>Closed At:</strong> <%= @crisis_event.closed_formatted %></span>
+          <% else %>
+            <span><strong>Active</strong> <i class="fas fa-exclamation-circle"></i></span>
+            <span><strong>Last Update At:</strong> <%= @crisis_event.last_update %></span>
+          <% end %>
         </div>
         <div class="card-body">
           <h5 class="card-title mb-3">Crisis Type: <%= @crisis_event.crisis_type.category %></h5>
-          <p class="card-text">Additional Info: <%= @crisis_event.additional_info %></p>
+
+          <p class="card-text">
+            <% if @crisis_event.additional_info.empty? %>
+              User has not provided any additional info
+            <%  else  %>
+              Additional Info: <%=  @crisis_event.additional_info  %>
+            <%  end %>
+          </p>
         </div>
           <div class="card-footer">
             <div class="container p-0">
               <div class="row">
                 <div class="col-6">
-                  <a class="btn btn-primary m-1" data-bs-toggle="modal" data-bs-target="#noteModal">New Note</a>
+                  <a class="btn btn-primary m-1" data-bs-toggle="modal" data-bs-target="#noteModal">New Note <i class="fas fa-plus-circle"></i></a>
                 </div>
                 <div class="col-6">
                   <% unless @crisis_event.closed %>
-                    <%= link_to 'Close', close_crisis_event_path(@crisis_event), class: 'btn btn-danger m-1',
-                                data: { method: 'put', confirm: 'A crisis event should only be closed if the crisis has been dealt with. Are you sure?' } %>
+                    <%= link_to close_crisis_event_path(@crisis_event), class: 'btn btn-danger m-1',
+                                data: { method: 'put', confirm: 'A crisis event should only be closed if the crisis has been dealt with. Are you sure?' } do %>
+                      Close Event <i class="fas fa-times-circle"></i>
+                    <% end %>
                   <% end %>
                 </div>
               </div>
@@ -42,10 +59,10 @@
       <div class="col">
         <h3>Notes</h3>
 
-        <div class="container">
+        <div class="container p-0">
           <div class="row">
             <% @notes.each do |note| %>
-              <div class="col-4">
+              <div class="col-12 col-md-6 col-lg-4">
                 <div class="card mb-3">
                   <div class="card-header">
                     <span><%= note.team_member.first_name %> <%= note.team_member.last_name %></span>

--- a/app/views/team_members/crisis_events/show.html.erb
+++ b/app/views/team_members/crisis_events/show.html.erb
@@ -1,0 +1,31 @@
+<main class="container team_members crisis_event">
+  <section class="row">
+    <div class="col-lg-3"></div>
+    <div class="col-lg-6">
+      <h3 class="mb-3">Crisis Event - <%= @crisis_event.user.first_name %> <%= @crisis_event.user.last_name %></h3>
+      <div class="card mb-3">
+        <div class="card-header">
+          <span>
+            <% if @crisis_event.closed %>
+              <strong>Closed</strong> <i class="fas fa-times-circle"></i>
+            <% else %>
+              <strong>Active</strong> <i class="fas fa-exclamation-circle"></i>
+            <% end %>
+          </span>
+          <span><%= @crisis_event.last_update %></span>
+        </div>
+        <div class="card-body">
+          <h5 class="card-title mb-3">Crisis Type: <%= @crisis_event.crisis_type.category %></h5>
+          <p class="card-text">Additional Info: <%= @crisis_event.additional_info %></p>
+        </div>
+        <% unless @crisis_event.closed %>
+          <div class="card-footer">
+            <%= link_to 'Close', close_crisis_event_path(@crisis_event), class: 'btn btn-primary',
+                        data: { method: 'put', confirm: 'A crisis event should only be closed if the crisis has been dealt with. Are you sure?' } %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="col-lg-3"></div>
+  </section>
+</main>

--- a/app/views/team_members/crisis_events/show.html.erb
+++ b/app/views/team_members/crisis_events/show.html.erb
@@ -10,7 +10,7 @@
     <div class="col-lg-3"></div>
     <div class="col-lg-6">
       <h3 class="mb-3">Crisis Event</h3>
-      <h5 class="mb-3"><%= @crisis_event.user.first_name %> <%= @crisis_event.user.last_name %>
+      <h5 class="mb-3"><%= link_to "#{@crisis_event.user.first_name} #{@crisis_event.user.last_name}", user_path(@crisis_event.user) %>
         raised an SOS <%= time_ago_in_words(@crisis_event.created_at) %> ago</h5>
       <% unless @crisis_event.closed %>
         <h5 class="mb-3">

--- a/app/views/team_members/crisis_events/show.html.erb
+++ b/app/views/team_members/crisis_events/show.html.erb
@@ -18,14 +18,73 @@
           <h5 class="card-title mb-3">Crisis Type: <%= @crisis_event.crisis_type.category %></h5>
           <p class="card-text">Additional Info: <%= @crisis_event.additional_info %></p>
         </div>
-        <% unless @crisis_event.closed %>
           <div class="card-footer">
-            <%= link_to 'Close', close_crisis_event_path(@crisis_event), class: 'btn btn-primary',
-                        data: { method: 'put', confirm: 'A crisis event should only be closed if the crisis has been dealt with. Are you sure?' } %>
+            <div class="container p-0">
+              <div class="row">
+                <div class="col-6">
+                  <a class="btn btn-primary m-1" data-bs-toggle="modal" data-bs-target="#noteModal">New Note</a>
+                </div>
+                <div class="col-6">
+                  <% unless @crisis_event.closed %>
+                    <%= link_to 'Close', close_crisis_event_path(@crisis_event), class: 'btn btn-danger m-1',
+                                data: { method: 'put', confirm: 'A crisis event should only be closed if the crisis has been dealt with. Are you sure?' } %>
+                  <% end %>
+                </div>
+              </div>
+            </div>
           </div>
-        <% end %>
       </div>
     </div>
     <div class="col-lg-3"></div>
   </section>
+  <% if @notes.present? %>
+    <section class="row">
+      <div class="col">
+        <h3>Notes</h3>
+
+        <div class="container">
+          <div class="row">
+            <% @notes.each do |note| %>
+              <div class="col-4">
+                <div class="card mb-3">
+                  <div class="card-header">
+                    <span><%= note.team_member.first_name %> <%= note.team_member.last_name %></span>
+                    <span><%= note.last_update %> </span>
+                  </div>
+                  <div class="card-body">
+                    <p class="card-text"><%= note.content %></p>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </section>
+  <% end %>
 </main>
+<div class="modal fade" id="noteModal" tabindex="-1" aria-labelledby="noteModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="sosModalLabel">New Note</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <%= form_with model: @note, url: crisis_event_notes_path(@crisis_event), method: :post do |f| %>
+          <div class="mb-2">
+            <%= f.text_area :content, class: 'form-control', style: 'height: 150px' %>
+          </div>
+
+          <div class="container">
+            <div class="row">
+              <div class="col text-center">
+                <%= f.submit 'Add', class: 'btn btn-primary mt-2' %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/team_members/crisis_events_pages/index.html.erb
+++ b/app/views/team_members/crisis_events_pages/index.html.erb
@@ -1,0 +1,51 @@
+<main class="container team_members crisis_events">
+  <section class="row">
+    <div class="col-12">
+      <h3>Closed Crisis Events</h3>
+      <table class="table table-dark table-striped">
+        <thead>
+        <th scope="col">User</th>
+        <th scope="col">Crisis Type</th>
+        <th scope="col">Additional Info</th>
+        <th scope="col">Last Update</th>
+        </thead>
+        <tbody>
+        <% @crisis_events.each do |crisis_event| %>
+          <tr>
+            <td>
+              <%= link_to "#{crisis_event.user.first_name} #{crisis_event.user.last_name}",
+                          crisis_event_path(crisis_event) %>
+            </td>
+            <td>
+              <%= link_to "#{crisis_event.crisis_type.category}", crisis_event_path(crisis_event) %>
+            </td>
+            <td>
+              <%= link_to "#{crisis_event.additional_info}", crisis_event_path(crisis_event) %>
+            </td>
+            <td>
+              <%= link_to "#{crisis_event.last_update}", crisis_event_path(crisis_event) %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+    <div class="col-12">
+      <div class="container controls">
+        <div class="row">
+          <div class="col">
+            <% unless @page == 1 %>
+              <%= link_to 'Previous', pages_crisis_events_path(@page - 1), class: 'btn btn-primary' %>
+            <% end %>
+          </div>
+          <div class="col"></div>
+          <div class="col">
+            <% unless @last_page %>
+              <%= link_to 'Next', pages_crisis_events_path(@page + 1), class: 'btn btn-primary' %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>

--- a/app/views/team_members/crisis_events_pages/index.html.erb
+++ b/app/views/team_members/crisis_events_pages/index.html.erb
@@ -8,7 +8,7 @@
           <th scope="col">User</th>
           <th scope="col">Crisis Type</th>
           <th scope="col">Additional Info</th>
-          <th scope="col">Last Update</th>
+          <th scope="col">Closed At</th>
           </thead>
           <tbody>
           <% @crisis_events.each do |crisis_event| %>
@@ -24,7 +24,7 @@
                 <%= link_to "#{crisis_event.additional_info}", crisis_event_path(crisis_event) %>
               </td>
               <td>
-                <%= link_to "#{crisis_event.last_update}", crisis_event_path(crisis_event) %>
+                <%= link_to "#{crisis_event.closed_formatted}", crisis_event_path(crisis_event) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/team_members/crisis_events_pages/index.html.erb
+++ b/app/views/team_members/crisis_events_pages/index.html.erb
@@ -1,4 +1,11 @@
 <main class="container team_members crisis_events">
+  <div class="row m-1 mt-3">
+    <div class="col">
+      <%= link_to crisis_events_path, class: 'btn btn-primary' do %>
+        <i class="fas fa-arrow-circle-left"></i> Back to active
+      <% end %>
+    </div>
+  </div>
   <section class="row">
     <div class="col">
       <h3>Closed Crisis Events</h3>
@@ -37,13 +44,17 @@
         <div class="row">
           <div class="col">
             <% unless @page == 1 %>
-              <%= link_to 'Previous', pages_crisis_events_path(@page - 1), class: 'btn btn-primary' %>
+              <%= link_to pages_crisis_events_path(@page - 1), class: 'btn btn-primary' do %>
+                <i class="fas fa-arrow-circle-left"></i> Previous
+              <% end %>
             <% end %>
           </div>
           <div class="col"></div>
           <div class="col">
             <% unless @last_page %>
-              <%= link_to 'Next', pages_crisis_events_path(@page + 1), class: 'btn btn-primary' %>
+              <%= link_to pages_crisis_events_path(@page + 1), class: 'btn btn-primary' do %>
+                Next <i class="fas fa-arrow-circle-right"></i>
+              <% end %>
             <% end %>
           </div>
         </div>

--- a/app/views/team_members/crisis_events_pages/index.html.erb
+++ b/app/views/team_members/crisis_events_pages/index.html.erb
@@ -1,34 +1,36 @@
 <main class="container team_members crisis_events">
   <section class="row">
-    <div class="col-12">
+    <div class="col">
       <h3>Closed Crisis Events</h3>
-      <table class="table table-dark table-striped">
-        <thead>
-        <th scope="col">User</th>
-        <th scope="col">Crisis Type</th>
-        <th scope="col">Additional Info</th>
-        <th scope="col">Last Update</th>
-        </thead>
-        <tbody>
-        <% @crisis_events.each do |crisis_event| %>
-          <tr>
-            <td>
-              <%= link_to "#{crisis_event.user.first_name} #{crisis_event.user.last_name}",
-                          crisis_event_path(crisis_event) %>
-            </td>
-            <td>
-              <%= link_to "#{crisis_event.crisis_type.category}", crisis_event_path(crisis_event) %>
-            </td>
-            <td>
-              <%= link_to "#{crisis_event.additional_info}", crisis_event_path(crisis_event) %>
-            </td>
-            <td>
-              <%= link_to "#{crisis_event.last_update}", crisis_event_path(crisis_event) %>
-            </td>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
+      <div class="table-container">
+        <table class="table table-dark table-striped link-table">
+          <thead>
+          <th scope="col">User</th>
+          <th scope="col">Crisis Type</th>
+          <th scope="col">Additional Info</th>
+          <th scope="col">Last Update</th>
+          </thead>
+          <tbody>
+          <% @crisis_events.each do |crisis_event| %>
+            <tr>
+              <td>
+                <%= link_to "#{crisis_event.user.first_name} #{crisis_event.user.last_name}",
+                            crisis_event_path(crisis_event) %>
+              </td>
+              <td>
+                <%= link_to "#{crisis_event.crisis_type.category}", crisis_event_path(crisis_event) %>
+              </td>
+              <td>
+                <%= link_to "#{crisis_event.additional_info}", crisis_event_path(crisis_event) %>
+              </td>
+              <td>
+                <%= link_to "#{crisis_event.last_update}", crisis_event_path(crisis_event) %>
+              </td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
     <div class="col-12">
       <div class="container controls">

--- a/app/views/team_members/dashboard/show.html.erb
+++ b/app/views/team_members/dashboard/show.html.erb
@@ -1,4 +1,4 @@
-<main class="container dashboard team_members">
+<main class="container team_members">
   <section class="row">
     <div class="col mb-3">
       <h3>Dashboard</h3>
@@ -42,6 +42,22 @@
               </div>
             </div>
           <% end %>
+        </div>
+        <div class="row">
+          <%= link_to crisis_events_path, class: 'col d-flex align-items-center btn' do %>
+            <div class="container">
+              <div class="row">
+                <div class="col">
+                  <i class="mb-1 fas fa-exclamation-circle"></i>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col">Crisis Events</div>
+              </div>
+            </div>
+          <% end %>
+          <a class="col col d-flex align-items-center" style="background-color: transparent; border-color: transparent"></a>
+          <a class="col col d-flex align-items-center" style="background-color: transparent; border-color: transparent"></a>
         </div>
       </div>
     </div>

--- a/app/views/team_members/dashboard/show.html.erb
+++ b/app/views/team_members/dashboard/show.html.erb
@@ -5,7 +5,7 @@
       <div class="container buttons">
         <div class="row">
           <% if current_team_member.admin? %>
-            <%= link_to '#team_members', class: 'col d-flex align-items-center btn' do %>
+            <%= link_to team_members_path, class: 'col d-flex align-items-center btn' do %>
               <div class="container">
                 <div class="row">
                   <div class="col">
@@ -18,7 +18,7 @@
               </div>
             <% end %>
           <% end %>
-          <%= link_to '#users', class: 'col d-flex align-items-center btn' do %>
+          <%= link_to users_path, class: 'col d-flex align-items-center btn' do %>
             <div class="container">
               <div class="row">
                 <div class="col">
@@ -60,148 +60,6 @@
           <a class="col col d-flex align-items-center" style="background-color: transparent; border-color: transparent"></a>
         </div>
       </div>
-    </div>
-  </section>
-  <% if current_team_member.admin? and @unapproved_team_members.count > 0 %>
-    <section class="row" id="awaiting_approval">
-      <div class="col">
-        <h3>Team Members Awaiting Approval</h3>
-        <table class="table table-dark table-striped align-middle">
-          <thead>
-            <th scope="col">First Name</th>
-            <th scope="col">Last Name</th>
-            <th scope="col">Email</th>
-            <th scope="col">Last Sign In Attempt</th>
-            <th scope="col"></th>
-          </thead>
-          <tbody>
-          <% @unapproved_team_members.each do |team_member| %>
-            <tr>
-              <td><%= team_member.first_name %></td>
-              <td><%= team_member.last_name %></td>
-              <td><%= team_member.email %></td>
-              <td><%= team_member.last_sign_in %></td>
-              <td>
-                <%= form_with url: approve_team_member_path(team_member.id), method: :put do |form| %>
-                  <%= form.hidden_field :team_member_id, value: team_member.id %>
-                  <%= form.submit 'Approve', class: 'btn btn-primary' %>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-          </tbody>
-        </table>
-      </div>
-    </section>
-  <% end %>
-  <% if current_team_member.admin? %>
-    <section class="row" id="team_members">
-      <div class="col">
-        <h3>Team Members</h3>
-        <table class="table table-dark table-striped align-middle">
-          <thead>
-            <th scope="col">First Name</th>
-            <th scope="col">Last Name</th>
-            <th scope="col">Email</th>
-            <th scope="col">Admin</th>
-            <th scope="col">Last Sign In</th>
-          </thead>
-          <tbody>
-            <% @approved_team_members.each do |team_member| %>
-              <tr>
-                <td>
-                  <%= link_to team_member_path(team_member) do %>
-                    <%= team_member.first_name %>
-                  <% end %>
-                </td>
-                <td>
-                  <%= link_to team_member_path(team_member) do %>
-                    <%= team_member.last_name %>
-                  <% end %>
-                </td>
-                <td>
-                  <%= link_to team_member_path(team_member) do %>
-                    <%= team_member.email %>
-                  <% end %>
-                </td>
-                <td>
-                  <% if current_team_member.id != team_member.id %>
-                    <%= form_with url: toggle_admin_team_member_path(team_member.id), method: :put do |form| %>
-                      <%= form.hidden_field :team_member_id, value: team_member.id %>
-                      <%= button_to '', { action: 'submit', class: 'btn w-100', data: {
-                        confirm: team_member.admin ?
-                                   "Demote #{team_member.first_name} #{team_member.last_name} from an admin role?" :
-                                   "Promote #{team_member.first_name} #{team_member.last_name} to an admin role?" }} do %>
-                        <% if team_member.admin %>
-                          <i class="fas fa-check-circle"></i>
-                        <% else %>
-                          <i class="fas fa-times-circle"></i>
-                        <% end %>
-                      <% end %>
-                    <% end %>
-                  <% else %>
-                    <% if team_member.admin %>
-                      <i class="fas fa-check-circle"></i>
-                    <% else %>
-                      <i class="fas fa-times-circle"></i>
-                    <% end %>
-                  <% end %>
-                </td>
-                <td>
-                  <%= link_to team_member_path(team_member) do %>
-                    <%= team_member.last_sign_in %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    </section>
-  <% end %>
-  <section class="row" id="users">
-    <div class="col">
-      <h2 class="mb-3">User</h2>
-      <table class="table table-dark table-striped">
-        <thead>
-          <th scope="col">First</th>
-          <th scope="col">Last</th>
-          <th scope="col">Release Date</th>
-          <th scope="col">Email</th>
-          <th scope="col">Last Sign In</th>
-        </thead>
-        <tbody>
-          <% @users.each do |user| %>
-            <tr>
-              <td>
-                <%= link_to user_path(user) do %>
-                  <%= user.first_name %>
-                <% end %>
-              </td>
-              <td>
-                <%= link_to user_path(user) do %>
-                  <%= user.last_name %>
-                <% end %>
-              </td>
-              <td>
-                <%= link_to user_path(user) do %>
-                  <%= user.release %>
-                <% end %>
-              </td>
-              <td>
-                <%= link_to user_path(user) do %>
-                  <%= user.email %>
-                <% end %>
-              </td>
-              <td>
-                <%= link_to user_path(user) do %>
-                  <%= user.last_sign_in %>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
     </div>
   </section>
 </main>

--- a/app/views/team_members/dashboard/show.html.erb
+++ b/app/views/team_members/dashboard/show.html.erb
@@ -42,23 +42,39 @@
               </div>
             </div>
           <% end %>
-        </div>
-        <div class="row">
-          <%= link_to crisis_events_path, class: 'col d-flex align-items-center btn' do %>
-            <div class="container">
-              <div class="row">
-                <div class="col">
-                  <i class="mb-1 fas fa-exclamation-circle"></i>
+          <% unless current_team_member.admin? %>
+            <%= link_to crisis_events_path, class: 'col d-flex align-items-center btn' do %>
+              <div class="container">
+                <div class="row">
+                  <div class="col">
+                    <i class="mb-1 fas fa-exclamation-circle"></i>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col">Crisis Events</div>
                 </div>
               </div>
-              <div class="row">
-                <div class="col">Crisis Events</div>
-              </div>
-            </div>
+            <% end %>
           <% end %>
-          <a class="col col d-flex align-items-center" style="background-color: transparent; border-color: transparent"></a>
-          <a class="col col d-flex align-items-center" style="background-color: transparent; border-color: transparent"></a>
         </div>
+        <% if current_team_member.admin?  %>
+          <div class="row">
+            <%= link_to crisis_events_path, class: 'col d-flex align-items-center btn' do %>
+              <div class="container">
+                <div class="row">
+                  <div class="col">
+                    <i class="mb-1 fas fa-exclamation-circle"></i>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col">Crisis Events</div>
+                </div>
+              </div>
+            <% end %>
+            <a class="col col d-flex align-items-center" style="background-color: transparent; border-color: transparent"></a>
+            <a class="col col d-flex align-items-center" style="background-color: transparent; border-color: transparent"></a>
+          </div>
+        <% end %>
       </div>
     </div>
   </section>

--- a/app/views/team_members/team_members/index.html.erb
+++ b/app/views/team_members/team_members/index.html.erb
@@ -3,25 +3,92 @@
     <section class="row" id="awaiting_approval">
       <div class="col">
         <h3>Team Members Awaiting Approval</h3>
-        <table class="table table-dark table-striped align-middle">
+        <div class="table-container">
+          <table class="table table-dark table-striped align-middle">
+            <thead>
+            <th scope="col">First Name</th>
+            <th scope="col">Last Name</th>
+            <th scope="col">Email</th>
+            <th scope="col">Last Sign In Attempt</th>
+            <th scope="col"></th>
+            </thead>
+            <tbody>
+            <% @unapproved_team_members.each do |team_member| %>
+              <tr>
+                <td><%= team_member.first_name %></td>
+                <td><%= team_member.last_name %></td>
+                <td><%= team_member.email %></td>
+                <td><%= team_member.last_sign_in %></td>
+                <td>
+                  <%= form_with url: approve_team_member_path(team_member.id), method: :put do |form| %>
+                    <%= form.hidden_field :team_member_id, value: team_member.id %>
+                    <%= form.submit 'Approve', class: 'btn btn-primary' %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  <% end %>
+  <section class="row" id="team_members">
+    <div class="col">
+      <h3>Team Members</h3>
+      <div class="table-container">
+        <table class="table table-dark table-striped align-middle link-table">
           <thead>
           <th scope="col">First Name</th>
           <th scope="col">Last Name</th>
           <th scope="col">Email</th>
-          <th scope="col">Last Sign In Attempt</th>
-          <th scope="col"></th>
+          <th scope="col">Admin</th>
+          <th scope="col">Last Sign In</th>
           </thead>
           <tbody>
-          <% @unapproved_team_members.each do |team_member| %>
+          <% @approved_team_members.each do |team_member| %>
             <tr>
-              <td><%= team_member.first_name %></td>
-              <td><%= team_member.last_name %></td>
-              <td><%= team_member.email %></td>
-              <td><%= team_member.last_sign_in %></td>
               <td>
-                <%= form_with url: approve_team_member_path(team_member.id), method: :put do |form| %>
-                  <%= form.hidden_field :team_member_id, value: team_member.id %>
-                  <%= form.submit 'Approve', class: 'btn btn-primary' %>
+                <%= link_to team_member_path(team_member) do %>
+                  <%= team_member.first_name %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to team_member_path(team_member) do %>
+                  <%= team_member.last_name %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to team_member_path(team_member) do %>
+                  <%= team_member.email %>
+                <% end %>
+              </td>
+              <td>
+                <% if current_team_member.id != team_member.id %>
+                  <%= form_with url: toggle_admin_team_member_path(team_member.id), method: :put do |form| %>
+                    <%= form.hidden_field :team_member_id, value: team_member.id %>
+                    <%= button_to '', { action: 'submit', class: 'btn w-100', data: {
+                      confirm: team_member.admin ?
+                                 "Demote #{team_member.first_name} #{team_member.last_name} from an admin role?" :
+                                 "Promote #{team_member.first_name} #{team_member.last_name} to an admin role?" }} do %>
+                      <% if team_member.admin %>
+                        <i class="fas fa-check-circle"></i>
+                      <% else %>
+                        <i class="fas fa-times-circle"></i>
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                <% else %>
+                  <% if team_member.admin %>
+                    <i class="fas fa-check-circle"></i>
+                  <% else %>
+                    <i class="fas fa-times-circle"></i>
+                  <% end %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to team_member_path(team_member) do %>
+                  <%= team_member.last_sign_in %>
                 <% end %>
               </td>
             </tr>
@@ -29,69 +96,6 @@
           </tbody>
         </table>
       </div>
-    </section>
-  <% end %>
-  <section class="row" id="team_members">
-    <div class="col">
-      <h3>Team Members</h3>
-      <table class="table table-dark table-striped align-middle">
-        <thead>
-        <th scope="col">First Name</th>
-        <th scope="col">Last Name</th>
-        <th scope="col">Email</th>
-        <th scope="col">Admin</th>
-        <th scope="col">Last Sign In</th>
-        </thead>
-        <tbody>
-        <% @approved_team_members.each do |team_member| %>
-          <tr>
-            <td>
-              <%= link_to team_member_path(team_member) do %>
-                <%= team_member.first_name %>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to team_member_path(team_member) do %>
-                <%= team_member.last_name %>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to team_member_path(team_member) do %>
-                <%= team_member.email %>
-              <% end %>
-            </td>
-            <td>
-              <% if current_team_member.id != team_member.id %>
-                <%= form_with url: toggle_admin_team_member_path(team_member.id), method: :put do |form| %>
-                  <%= form.hidden_field :team_member_id, value: team_member.id %>
-                  <%= button_to '', { action: 'submit', class: 'btn w-100', data: {
-                    confirm: team_member.admin ?
-                               "Demote #{team_member.first_name} #{team_member.last_name} from an admin role?" :
-                               "Promote #{team_member.first_name} #{team_member.last_name} to an admin role?" }} do %>
-                    <% if team_member.admin %>
-                      <i class="fas fa-check-circle"></i>
-                    <% else %>
-                      <i class="fas fa-times-circle"></i>
-                    <% end %>
-                  <% end %>
-                <% end %>
-              <% else %>
-                <% if team_member.admin %>
-                  <i class="fas fa-check-circle"></i>
-                <% else %>
-                  <i class="fas fa-times-circle"></i>
-                <% end %>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to team_member_path(team_member) do %>
-                <%= team_member.last_sign_in %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
     </div>
   </section>
 </main>

--- a/app/views/team_members/team_members/index.html.erb
+++ b/app/views/team_members/team_members/index.html.erb
@@ -1,0 +1,97 @@
+<main class="container team_members">
+  <% if @unapproved_team_members.count > 0 %>
+    <section class="row" id="awaiting_approval">
+      <div class="col">
+        <h3>Team Members Awaiting Approval</h3>
+        <table class="table table-dark table-striped align-middle">
+          <thead>
+          <th scope="col">First Name</th>
+          <th scope="col">Last Name</th>
+          <th scope="col">Email</th>
+          <th scope="col">Last Sign In Attempt</th>
+          <th scope="col"></th>
+          </thead>
+          <tbody>
+          <% @unapproved_team_members.each do |team_member| %>
+            <tr>
+              <td><%= team_member.first_name %></td>
+              <td><%= team_member.last_name %></td>
+              <td><%= team_member.email %></td>
+              <td><%= team_member.last_sign_in %></td>
+              <td>
+                <%= form_with url: approve_team_member_path(team_member.id), method: :put do |form| %>
+                  <%= form.hidden_field :team_member_id, value: team_member.id %>
+                  <%= form.submit 'Approve', class: 'btn btn-primary' %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% end %>
+  <section class="row" id="team_members">
+    <div class="col">
+      <h3>Team Members</h3>
+      <table class="table table-dark table-striped align-middle">
+        <thead>
+        <th scope="col">First Name</th>
+        <th scope="col">Last Name</th>
+        <th scope="col">Email</th>
+        <th scope="col">Admin</th>
+        <th scope="col">Last Sign In</th>
+        </thead>
+        <tbody>
+        <% @approved_team_members.each do |team_member| %>
+          <tr>
+            <td>
+              <%= link_to team_member_path(team_member) do %>
+                <%= team_member.first_name %>
+              <% end %>
+            </td>
+            <td>
+              <%= link_to team_member_path(team_member) do %>
+                <%= team_member.last_name %>
+              <% end %>
+            </td>
+            <td>
+              <%= link_to team_member_path(team_member) do %>
+                <%= team_member.email %>
+              <% end %>
+            </td>
+            <td>
+              <% if current_team_member.id != team_member.id %>
+                <%= form_with url: toggle_admin_team_member_path(team_member.id), method: :put do |form| %>
+                  <%= form.hidden_field :team_member_id, value: team_member.id %>
+                  <%= button_to '', { action: 'submit', class: 'btn w-100', data: {
+                    confirm: team_member.admin ?
+                               "Demote #{team_member.first_name} #{team_member.last_name} from an admin role?" :
+                               "Promote #{team_member.first_name} #{team_member.last_name} to an admin role?" }} do %>
+                    <% if team_member.admin %>
+                      <i class="fas fa-check-circle"></i>
+                    <% else %>
+                      <i class="fas fa-times-circle"></i>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              <% else %>
+                <% if team_member.admin %>
+                  <i class="fas fa-check-circle"></i>
+                <% else %>
+                  <i class="fas fa-times-circle"></i>
+                <% end %>
+              <% end %>
+            </td>
+            <td>
+              <%= link_to team_member_path(team_member) do %>
+                <%= team_member.last_sign_in %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</main>

--- a/app/views/team_members/team_members/show.html.erb
+++ b/app/views/team_members/team_members/show.html.erb
@@ -1,4 +1,4 @@
-<main class="container dashboard team_member">
+<main class="container team_members team_member">
   <section class="row">
     <div class="col">
       <h3>Team Member Details</h3>

--- a/app/views/team_members/team_members/show.html.erb
+++ b/app/views/team_members/team_members/show.html.erb
@@ -2,58 +2,62 @@
   <section class="row">
     <div class="col">
       <h3>Team Member Details</h3>
-      <table class="table table-dark table-striped">
-        <thead>
-          <th scope="col">First Name</th>
-          <th scope="col">Last Name</th>
-          <th scope="col">Email</th>
-          <th scope="col">Mobile No.</th>
-          <th scope="col">Admin</th>
-          <th scope="col">Created At</th>
-          <th scope="col">Last Update</th>
-        </thead>
-        <tbody>
-          <tr>
-            <td><%= @team_member.first_name %></td>
-            <td><%= @team_member.last_name %></td>
-            <td><%= @team_member.email %></td>
-            <td>0<%= @team_member.mobile_number %></td>
-            <td>
-              <% if @team_member.admin %>
-                <i class="fas fa-check-circle"></i>
-              <% else %>
-                <i class="fas fa-times-circle"></i>
-              <% end %>
-            </td>
-            <td><%= @team_member.created %></td>
-            <td><%= @team_member.last_update %></td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="table-container">
+        <table class="table table-dark table-striped">
+          <thead>
+            <th scope="col">First Name</th>
+            <th scope="col">Last Name</th>
+            <th scope="col">Email</th>
+            <th scope="col">Mobile No.</th>
+            <th scope="col">Admin</th>
+            <th scope="col">Created At</th>
+            <th scope="col">Last Update</th>
+          </thead>
+          <tbody>
+            <tr>
+              <td><%= @team_member.first_name %></td>
+              <td><%= @team_member.last_name %></td>
+              <td><%= @team_member.email %></td>
+              <td>0<%= @team_member.mobile_number %></td>
+              <td>
+                <% if @team_member.admin %>
+                  <i class="fas fa-check-circle"></i>
+                <% else %>
+                  <i class="fas fa-times-circle"></i>
+                <% end %>
+              </td>
+              <td><%= @team_member.created %></td>
+              <td><%= @team_member.last_update %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </section>
   <% if @team_member.sign_in_count > 0 %>
     <section class="row">
       <div class="col">
         <h3>Team Member Sign In</h3>
-        <table class="table table-dark table-striped">
-          <thead>
-            <th scope="col">Sign In Count</th>
-            <th scope="col">Current Sign In</th>
-            <th scope="col">Current Sign In IP</th>
-            <th scope="col">Last Sign In</th>
-            <th scope="col">Last Sign In IP</th>
-          </thead>
-          <tbody>
-            <tr>
-              <td><%= @team_member.sign_in_count %></td>
-              <td><%= @team_member.current_sign_in %></td>
-              <td><%= @team_member.current_sign_in_ip %></td>
-              <td><%= @team_member.last_sign_in %></td>
-              <td><%= @team_member.last_sign_in_ip %></td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="table-container">
+          <table class="table table-dark table-striped">
+            <thead>
+              <th scope="col">Sign In Count</th>
+              <th scope="col">Current Sign In</th>
+              <th scope="col">Current Sign In IP</th>
+              <th scope="col">Last Sign In</th>
+              <th scope="col">Last Sign In IP</th>
+            </thead>
+            <tbody>
+              <tr>
+                <td><%= @team_member.sign_in_count %></td>
+                <td><%= @team_member.current_sign_in %></td>
+                <td><%= @team_member.current_sign_in_ip %></td>
+                <td><%= @team_member.last_sign_in %></td>
+                <td><%= @team_member.last_sign_in_ip %></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </section>
   <% end %>
@@ -61,34 +65,36 @@
     <section class="row">
       <div class="col">
         <h3>wellbeing assessments</h3>
-        <table class="table table-dark table-striped">
-          <thead>
-            <th scope="col">User</th>
-            <th scope="col">Created At</th>
-            <th scope="col">Last Update</th>
-          </thead>
-          <tbody>
-            <% @team_member.wba_team_members.order(:created_at).each do |wba_team_member| %>
-              <tr>
-                <td>
-                  <%= link_to user_path(wba_team_member.user) do %>
-                    <%= wba_team_member.user.first_name %> <%= wba_team_member.user.last_name %>
-                  <% end %>
+        <div class="table-container">
+          <table class="table table-dark table-striped link-table">
+            <thead>
+              <th scope="col">User</th>
+              <th scope="col">Created At</th>
+              <th scope="col">Last Update</th>
+            </thead>
+            <tbody>
+              <% @team_member.wba_team_members.order(:created_at).each do |wba_team_member| %>
+                <tr>
+                  <td>
+                    <%= link_to user_path(wba_team_member.user) do %>
+                      <%= wba_team_member.user.first_name %> <%= wba_team_member.user.last_name %>
+                    <% end %>
+                  </td>
+                  <td>
+                    <%= link_to team_member_wba_team_member_path(@team_member, wba_team_member) do %>
+                      <%= wba_team_member.created %>
+                    <% end %>
+                  </td>
+                  <td>
+                    <%= link_to team_member_wba_team_member_path(@team_member, wba_team_member) do %>
+                      <%= wba_team_member.last_update %>
+                    <% end %>
                 </td>
-                <td>
-                  <%= link_to team_member_wba_team_member_path(@team_member, wba_team_member) do %>
-                    <%= wba_team_member.created %>
-                  <% end %>
-                </td>
-                <td>
-                  <%= link_to team_member_wba_team_member_path(@team_member, wba_team_member) do %>
-                    <%= wba_team_member.last_update %>
-                  <% end %>
-              </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
       </div>
     </section>
   <% end %>
@@ -96,22 +102,24 @@
     <section class="row">
       <div class="col">
         <h3>wellbeing assessment view logs</h3>
-        <table class="table table-dark table-striped">
-          <thead>
-          <th scope="col">User</th>
-          <th scope="col">Created At</th>
-          <th scope="col">Last Update</th>
-          </thead>
-          <tbody>
-          <% @team_member.wba_self_view_logs.includes(:user).order(:created_at).each do |wba_self_view_log| %>
-            <tr>
-              <td><%= wba_self_view_log.user.first_name %> <%= wba_self_view_log.user.last_name %></td>
-              <td><%= wba_self_view_log.created %>
-              <td><%= wba_self_view_log.last_update %>
-            </tr>
-          <% end %>
-          </tbody>
-        </table>
+        <div class="table-container">
+          <table class="table table-dark table-striped">
+            <thead>
+            <th scope="col">User</th>
+            <th scope="col">Created At</th>
+            <th scope="col">Last Update</th>
+            </thead>
+            <tbody>
+            <% @team_member.wba_self_view_logs.includes(:user).order(:created_at).each do |wba_self_view_log| %>
+              <tr>
+                <td><%= wba_self_view_log.user.first_name %> <%= wba_self_view_log.user.last_name %></td>
+                <td><%= wba_self_view_log.created %>
+                <td><%= wba_self_view_log.last_update %>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
       </div>
     </section>
   <% end %>

--- a/app/views/team_members/users/index.html.erb
+++ b/app/views/team_members/users/index.html.erb
@@ -1,0 +1,47 @@
+<main class="container team_members">
+  <section class="row" id="users">
+    <div class="col">
+      <h2 class="mb-3">Users</h2>
+      <table class="table table-dark table-striped">
+        <thead>
+        <th scope="col">First</th>
+        <th scope="col">Last</th>
+        <th scope="col">Release Date</th>
+        <th scope="col">Email</th>
+        <th scope="col">Last Sign In</th>
+        </thead>
+        <tbody>
+        <% @users.each do |user| %>
+          <tr>
+            <td>
+              <%= link_to user_path(user) do %>
+                <%= user.first_name %>
+              <% end %>
+            </td>
+            <td>
+              <%= link_to user_path(user) do %>
+                <%= user.last_name %>
+              <% end %>
+            </td>
+            <td>
+              <%= link_to user_path(user) do %>
+                <%= user.release %>
+              <% end %>
+            </td>
+            <td>
+              <%= link_to user_path(user) do %>
+                <%= user.email %>
+              <% end %>
+            </td>
+            <td>
+              <%= link_to user_path(user) do %>
+                <%= user.last_sign_in %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</main>

--- a/app/views/team_members/users/index.html.erb
+++ b/app/views/team_members/users/index.html.erb
@@ -1,47 +1,49 @@
 <main class="container team_members">
   <section class="row" id="users">
     <div class="col">
-      <h2 class="mb-3">Users</h2>
-      <table class="table table-dark table-striped">
-        <thead>
-        <th scope="col">First</th>
-        <th scope="col">Last</th>
-        <th scope="col">Release Date</th>
-        <th scope="col">Email</th>
-        <th scope="col">Last Sign In</th>
-        </thead>
-        <tbody>
-        <% @users.each do |user| %>
-          <tr>
-            <td>
-              <%= link_to user_path(user) do %>
-                <%= user.first_name %>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to user_path(user) do %>
-                <%= user.last_name %>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to user_path(user) do %>
-                <%= user.release %>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to user_path(user) do %>
-                <%= user.email %>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to user_path(user) do %>
-                <%= user.last_sign_in %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
+      <h3>Users</h3>
+      <div class="table-container">
+        <table class="table table-dark table-striped link-table">
+          <thead>
+          <th scope="col">First</th>
+          <th scope="col">Last</th>
+          <th scope="col">Release Date</th>
+          <th scope="col">Email</th>
+          <th scope="col">Last Sign In</th>
+          </thead>
+          <tbody>
+          <% @users.each do |user| %>
+            <tr>
+              <td>
+                <%= link_to user_path(user) do %>
+                  <%= user.first_name %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to user_path(user) do %>
+                  <%= user.last_name %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to user_path(user) do %>
+                  <%= user.release %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to user_path(user) do %>
+                  <%= user.email %>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to user_path(user) do %>
+                  <%= user.last_sign_in %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
   </section>
 </main>

--- a/app/views/users/journal_entries/index.html.erb
+++ b/app/views/users/journal_entries/index.html.erb
@@ -20,23 +20,23 @@
               </div>
             </div>
           <% end %>
-            <div class="col-12">
-              <div class="container controls">
-                <div class="row">
-                  <div class="col">
-                    <% unless @page == 1 %>
-                      <%= link_to 'Previous', pages_journal_entries_path(@page - 1), class: 'btn btn-primary' %>
-                    <% end %>
-                  </div>
-                  <div class="col"></div>
-                  <div class="col">
-                    <% unless last_page %>
-                      <%= link_to 'Next', pages_journal_entries_path(@page + 1), class: 'btn btn-primary' %>
-                    <% end %>
-                  </div>
+          <div class="col-12">
+            <div class="container controls">
+              <div class="row">
+                <div class="col">
+                  <% unless @page == 1 %>
+                    <%= link_to 'Previous', pages_journal_entries_path(@page - 1), class: 'btn btn-primary' %>
+                  <% end %>
+                </div>
+                <div class="col"></div>
+                <div class="col">
+                  <% unless @last_page %>
+                    <%= link_to 'Next', pages_journal_entries_path(@page + 1), class: 'btn btn-primary' %>
+                  <% end %>
                 </div>
               </div>
             </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/users/journal_entry_permissions/new.html.erb
+++ b/app/views/users/journal_entry_permissions/new.html.erb
@@ -16,15 +16,11 @@
             <div class="row">
               <%  @team_members.each do |team_member| %>
                 <div class="col-6 p-1">
-                  <%= f.check_box "team_member_#{team_member.id}", class: 'btn-check',
-                                  checked: last_permission(@last_permissions, team_member.id) %>
-                  <%= f.label "team_member_#{team_member.id}", class: 'btn w-100' do %>
+                  <% permitted = last_permission(@last_permissions, team_member.id) %>
+                  <%= f.check_box "team_member_#{team_member.id}", class: 'btn-check', checked: permitted %>
+                  <%= f.label "team_member_#{team_member.id}", class: "btn w-100 #{ permitted ? 'selected' : '' }" do %>
                     <%= team_member.first_name %> <%= team_member.last_name %>
-                    <% if last_permission(@last_permissions, team_member.id) %>
-                      <i class="fas fa-check-circle"></i>
-                    <% else %>
-                      <i class="fas fa-times-circle"></i>
-                    <% end %>
+                    <i class="fas <%= permitted ? 'fa-check-circle' : 'fa-times-circle'%>"></i>
                   <% end %>
                 </div>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,9 @@ Rails.application.routes.draw do
       end
 
       resources :users, only: :show, as: :user
+      resources :crisis_events, only: %i[show index], as: :crisis_events do
+        put 'close', action: 'close', on: :member, as: :close
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
       resources :crisis_events, only: %i[show index], as: :crisis_events do
         put 'close', action: 'close', on: :member, as: :close
         get 'page/:page_number', to: 'crisis_events_pages#index', on: :collection, as: :pages
+
+        resources :crisis_events_notes, only: %i[new create], as: :notes
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
     scope module: 'team_members' do
       root 'dashboard#show', as: :authenticated_team_member_root
 
-      resources :team_members, only: :show do
+      resources :team_members, only: %i[index show] do
         scope controller: 'team_members' do
           put 'approve', action: 'approve_team_member', on: :member, as: :approve
           put 'admin', action: 'toggle_admin', on: :member, as: :toggle_admin
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
         resources :wba_team_members, path: 'wba', only: :show, as: :wba_team_member
       end
 
-      resources :users, only: :show, as: :user
+      resources :users, only: %i[index show]
       resources :crisis_events, only: %i[show index], as: :crisis_events do
         put 'close', action: 'close', on: :member, as: :close
         get 'page/:page_number', to: 'crisis_events_pages#index', on: :collection, as: :pages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
       resources :users, only: :show, as: :user
       resources :crisis_events, only: %i[show index], as: :crisis_events do
         put 'close', action: 'close', on: :member, as: :close
+        get 'page/:page_number', to: 'crisis_events_pages#index', on: :collection, as: :pages
       end
     end
   end


### PR DESCRIPTION
Team members can now see all of the Crisis Event records that have been created from their scope via the 'Crisis Events' button on the homepage. This will take them to the index view which lists only the active crisis events with the option of viewing the closed crisis events via a button which will take the user to a paginated view for all of the closed crisis events sorted by creation date newest to oldest.

A team member can click on a crisis event in either the active crisis events index or the paginated closed crisis events index and be taken to the crisis event member record where they can see the full details of the crisis events along with the option to close the crisis event and add notes to the crisis event.

Crisis events button on homepage
<img width="1440" alt="Screenshot 2021-03-16 at 14 30 35" src="https://user-images.githubusercontent.com/6815945/111327338-35f50100-8665-11eb-82e3-8b5fd9112606.png">

Active crisis events index
<img width="1440" alt="Screenshot 2021-03-16 at 14 30 48" src="https://user-images.githubusercontent.com/6815945/111327420-473e0d80-8665-11eb-8d4f-1a1935518f13.png">

Paginated closed crisis events index
<img width="1440" alt="Screenshot 2021-03-16 at 14 30 54" src="https://user-images.githubusercontent.com/6815945/111327491-5755ed00-8665-11eb-961a-e496fae61288.png">

Crisis event member view
<img width="1440" alt="Screenshot 2021-03-16 at 14 31 11" src="https://user-images.githubusercontent.com/6815945/111327570-663c9f80-8665-11eb-83c9-3d2f9ab85072.png">
