### PR TITLE
Feature/ij 82 team member user index pagination

### DIFF
--- a/app/controllers/team_members/journal_entry_view_logs_controller.rb
+++ b/app/controllers/team_members/journal_entry_view_logs_controller.rb
@@ -9,7 +9,7 @@ module TeamMembers
     end
 
     def team_member
-      @team_member = TeamMember.includes(:journal_entry_view_logs).find(params[:id])
+      @team_member = TeamMember.includes(:journal_entry_view_logs).find(params[:team_member_id])
     end
   end
 end

--- a/app/controllers/team_members/pagination_controller.rb
+++ b/app/controllers/team_members/pagination_controller.rb
@@ -1,8 +1,7 @@
 module TeamMembers
   # app/controllers/team_members/pagination_controller.rb
   class PaginationController < TeamMembersApplicationController
-    before_action :page, :limit, :offset, :resources, :count, :last_page, :limit_resources, only: :index
-    before_action :redirect, only: :index, unless: -> { @resources.present? }
+    before_action :page, :limit, :offset, :resources, :count, :last_page, :limit_resources, :redirect, only: :index
 
     def index
       render 'index'
@@ -33,15 +32,23 @@ module TeamMembers
     end
 
     def page
-      @page = params[:page_number].to_i
+      @page = query_params[:page].to_i
+
+      @page = 1 if @page < 1
     end
 
     def limit_resources
-      @resources = @resources.offset(@offset).limit(@limit).order(created_at: :desc)
+      @resources = @resources.offset(@offset).limit(@limit)
+    end
+
+    def query_params
+      params.permit(:page)
     end
 
     def redirect
-      redirect_back(fallback_location: root_path, alert: 'None found')
+      return if @resources.present?
+
+      redirect_back(fallback_location: root_path, alert: 'No Results Found')
     end
   end
 end

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -1,19 +1,13 @@
 module TeamMembers
   # app/controllers/team_members/users_controller.rb
-  class UsersController < TeamMembersApplicationController
+  class UsersController < PaginationController
     before_action :user, except: %i[index search]
     before_action :maximum, :user_pin, except: %i[show index search]
     before_action :verify_pin, only: :pin
     before_action :verify_unpin, only: :unpin
     before_action :query, :pinned_users, :active_users, only: :index
 
-    before_action :users, only: :index, unless: -> { @query.present? }
-    before_action :search_users, only: :index, if: -> { @query.present? }
-
-    # GET /users?query=:query
-    def index
-      render 'index'
-    end
+    before_action :search, :redirect, only: :index, if: -> { @query.present? }
 
     # GET /users/:id
     def show
@@ -46,6 +40,17 @@ module TeamMembers
                     alert: @user_pin.decrement ? message('pin successfully moved') : message('pin could not be moved'))
     end
 
+    protected
+
+    def limit
+      @limit = 6
+    end
+
+    def resources
+      @resources = User.includes(:wba_selves, :crisis_events).where.not(id: current_team_member.pinned_users)
+                       .order(created_at: :desc)
+    end
+
     private
 
     def active_users
@@ -60,17 +65,21 @@ module TeamMembers
       "#{@user.full_name} #{message}"
     end
 
+    def query_params
+      params.permit(:query, :page)
+    end
+
     def pinned_users
       @pinned_users = current_team_member.pinned_users.order(:order)
     end
 
     def query
-      @query = params[:query]
+      @query = query_params[:query]
     end
 
-    def search_users
-      @users = User.where('lower(first_name) like lower(?) or lower(last_name) like lower(?)',
-                          "%#{@query}%", "%#{@query}%")
+    def search
+      @resources = User.where('lower(first_name) like lower(?) or lower(last_name) like lower(?)',
+                              "%#{@query}%", "%#{@query}%")
     end
 
     def user
@@ -79,10 +88,6 @@ module TeamMembers
 
     def user_pin
       @user_pin = current_team_member.user_pins.find_by(user_id: @user.id)
-    end
-
-    def users
-      @users = User.includes(:wba_selves, :crisis_events).where.not(id: @pinned_users).order(created_at: :desc)
     end
 
     def verify_pin

--- a/app/controllers/users/journal_entry_permissions_controller.rb
+++ b/app/controllers/users/journal_entry_permissions_controller.rb
@@ -11,7 +11,7 @@ module Users
     protected
 
     def path
-      pages_journal_entries_path(1)
+      journal_entries_path
     end
 
     def new_path

--- a/app/controllers/users/pagination_controller.rb
+++ b/app/controllers/users/pagination_controller.rb
@@ -1,8 +1,8 @@
 module Users
   # app/controllers/users/pagination_controller.rb
   class PaginationController < UsersApplicationController
-    before_action :page, :limit, :offset, :resources, :count, :last_page, :limit_resources, only: :index
-    before_action :redirect, only: :index, unless: -> { @resources.present? }
+    before_action :query_params, :page, :limit, :offset, :resources,
+                  :count, :last_page, :limit_resources, :redirect, only: :index
 
     def index
       render 'index'
@@ -33,14 +33,22 @@ module Users
     end
 
     def page
-      @page = params[:page_number].to_i
+      @page = params[:page].to_i
+
+      @page = 1 if @page < 1
     end
 
     def limit_resources
       @resources = @resources.offset(@offset).limit(@limit).order(created_at: :desc)
     end
 
+    def query_params
+      params.permit(:page)
+    end
+
     def redirect
+      return if @resources.present?
+
       redirect_back(fallback_location: root_path, alert: 'None found')
     end
   end

--- a/app/javascript/packs/user_search.js
+++ b/app/javascript/packs/user_search.js
@@ -3,11 +3,13 @@ const user_search = document.querySelector('#user-search'),
       search = function() {
           const search_params = new URLSearchParams(window.location.search)
           search_params.set('query', search_input.value)
+          if (search_params.has('page')) {
+              search_params.delete('page')
+          }
 
           history.pushState(null, null, `?${search_params.toString()}`)
           location.reload()
       }
-
 
 user_search.addEventListener('click', search)
 search_input.addEventListener('keyup', e => { if (e.key === 'Enter') search() })

--- a/app/views/team_members/crisis_events/active.html.erb
+++ b/app/views/team_members/crisis_events/active.html.erb
@@ -41,7 +41,7 @@
       <% else %>
         <h3>No active crisis events</h3>
       <% end %>
-      <%= link_to 'View Closed', pages_crisis_events_path(1), class: 'btn btn-primary' %>
+      <%= link_to 'View Closed', crisis_events_path, class: 'btn btn-primary' %>
     </div>
   </section>
 </main>

--- a/app/views/team_members/crisis_events/index.html.erb
+++ b/app/views/team_members/crisis_events/index.html.erb
@@ -45,7 +45,7 @@
         <div class="row">
           <div class="col">
             <% unless @page == 1 %>
-              <%= link_to pages_crisis_events_path(@page - 1), class: 'btn btn-primary' do %>
+              <%= link_to crisis_events_path(page: @page - 1), class: 'btn btn-primary' do %>
                 <i class="fas fa-arrow-circle-left"></i> Previous
               <% end %>
             <% end %>
@@ -53,7 +53,7 @@
           <div class="col"></div>
           <div class="col">
             <% unless @last_page %>
-              <%= link_to pages_crisis_events_path(@page + 1), class: 'btn btn-primary' do %>
+              <%= link_to crisis_events_path(page: @page + 1), class: 'btn btn-primary' do %>
                 Next <i class="fas fa-arrow-circle-right"></i>
               <% end %>
             <% end %>

--- a/app/views/team_members/dashboard/show.html.erb
+++ b/app/views/team_members/dashboard/show.html.erb
@@ -71,7 +71,7 @@
                 </div>
               </div>
             <% end %>
-            <%= link_to pages_journal_entries_path(1), class: 'col d-flex align-items-center btn' do %>
+            <%= link_to journal_entries_path, class: 'col d-flex align-items-center btn' do %>
               <div class="container">
                 <div class="row">
                   <div class="col">
@@ -87,7 +87,7 @@
           </div>
         <% else %>
           <div class="row">
-            <%= link_to pages_journal_entries_path(1), class: 'col d-flex align-items-center btn' do %>
+            <%= link_to journal_entries_path, class: 'col d-flex align-items-center btn' do %>
               <div class="container">
                 <div class="row">
                   <div class="col">

--- a/app/views/team_members/journal_entries/index.html.erb
+++ b/app/views/team_members/journal_entries/index.html.erb
@@ -49,7 +49,7 @@
         <div class="row">
           <div class="col">
             <% unless @page == 1 %>
-              <%= link_to pages_journal_entries_path(@page - 1), class: 'btn btn-primary' do %>
+              <%= link_to journal_entries_path(page: @page - 1), class: 'btn btn-primary' do %>
                 <i class="fas fa-arrow-circle-left"></i> Previous
               <% end %>
             <% end %>
@@ -57,7 +57,7 @@
           <div class="col"></div>
           <div class="col">
             <% unless @last_page %>
-              <%= link_to pages_journal_entries_path(@page + 1), class: 'btn btn-primary' do %>
+              <%= link_to journal_entries_path(page: @page + 1), class: 'btn btn-primary' do %>
                 Next <i class="fas fa-arrow-circle-right"></i>
               <% end %>
             <% end %>

--- a/app/views/team_members/journal_entry_view_logs/index.html.erb
+++ b/app/views/team_members/journal_entry_view_logs/index.html.erb
@@ -31,13 +31,13 @@
         <div class="row">
           <div class="col">
             <% unless @page == 1 %>
-              <%= link_to 'Previous', journal_entry_view_logs_team_member_path(@team_member, @page - 1), class: 'btn btn-primary' %>
+              <%= link_to 'Previous', team_member_journal_entry_view_logs_path(@team_member, page: @page - 1), class: 'btn btn-primary' %>
             <% end %>
           </div>
           <div class="col"></div>
           <div class="col">
             <% unless @last_page %>
-              <%= link_to 'Next', journal_entry_view_logs_team_member_path(@team_member, @page + 1), class: 'btn btn-primary' %>
+              <%= link_to 'Next', team_member_journal_entry_view_logs_path(@team_member, page: @page + 1), class: 'btn btn-primary' %>
             <% end %>
           </div>
         </div>

--- a/app/views/team_members/team_members/show.html.erb
+++ b/app/views/team_members/team_members/show.html.erb
@@ -35,7 +35,7 @@
               </div>
             </div>
           <% end %>
-          <%= link_to journal_entry_view_logs_team_member_path(@team_member, 1), class: 'col d-flex align-items-center btn' do %>
+          <%= link_to team_member_journal_entry_view_logs_path(@team_member), class: 'col d-flex align-items-center btn' do %>
             <div class="container">
               <div class="row">
                 <div class="col">

--- a/app/views/team_members/users/index.html.erb
+++ b/app/views/team_members/users/index.html.erb
@@ -15,7 +15,7 @@
             <div class="input-group">
               <span class="input-group-text" id="total-users">Total Users</span>
               <input type="text" class="form-control" aria-label="Total Users" aria-describedby="total-users"
-              value="<%= @users.count + @pinned_users.count %>" disabled>
+              value="<%= @resources.count + @pinned_users.count %>" disabled>
               <span class="input-group-text"><i class="fas fa-users"></i></span>
             </div>
           </div>
@@ -52,17 +52,36 @@
       </div>
     </section>
   <% end %>
-  <section class="row">
+  <section class="row" id="users">
     <div class="col">
       <h3><%= @query.present? ? '' : 'All' %> users</h3>
       <div class="container p-0">
         <div class="row">
-          <% @users.each do |user| %>
+          <% @resources.each do |user| %>
             <%= render 'card', user: user, pinned: false %>
           <% end %>
         </div>
       </div>
     </div>
+    <% unless @query.present? %>
+      <div class="col-12">
+        <div class="container pagination-controls">
+          <div class="row">
+            <div class="col">
+              <% unless @page == 1 %>
+                <%= link_to 'Previous', users_path(page: @page - 1, anchor: "users"), class: 'btn btn-primary' %>
+              <% end %>
+            </div>
+            <div class="col"></div>
+            <div class="col">
+              <% unless @last_page %>
+                <%= link_to 'Next', users_path(page: @page + 1, anchor: "users"), class: 'btn btn-primary' %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
   </section>
 </main>
 

--- a/app/views/users/journal_entries/dashboard.html.erb
+++ b/app/views/users/journal_entries/dashboard.html.erb
@@ -23,7 +23,7 @@
                 </div>
               </div>
             <% end %>
-            <%= link_to pages_journal_entries_path(1), class: 'col d-flex align-items-center btn' do %>
+            <%= link_to journal_entries_path, class: 'col d-flex align-items-center btn' do %>
               <div class="container">
                 <div class="row">
                   <div class="col">

--- a/app/views/users/journal_entries/index.html.erb
+++ b/app/views/users/journal_entries/index.html.erb
@@ -28,12 +28,12 @@
     <div class="row pagination-controls">
       <div class="col">
         <% unless @page == 1 %>
-          <%= link_to 'Previous', pages_journal_entries_path(@page - 1), class: 'btn btn-primary' %>
+          <%= link_to 'Previous', journal_entries_path(page: @page - 1), class: 'btn btn-primary' %>
         <% end %>
       </div>
       <div class="col text-end">
         <% unless @last_page %>
-          <%= link_to 'Next', pages_journal_entries_path(@page + 1), class: 'btn btn-primary' %>
+          <%= link_to 'Next', journal_entries_path(page: @page + 1), class: 'btn btn-primary' %>
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
         put 'approve', action: 'approve_team_member', on: :member, as: :approve
         put 'admin', action: 'toggle_admin', on: :member, as: :toggle_admin
 
-        get 'journal_entry_view_logs/page/:page_number', to: 'journal_entry_view_logs#index', on: :member, as: :journal_entry_view_logs
+        resources :journal_entry_view_logs, only: :index, on: :member
       end
 
       resources :users, only: %i[index show] do
@@ -48,18 +48,14 @@ Rails.application.routes.draw do
         put 'unpin', action: 'unpin', on: :member, as: :unpin
       end
 
-      resources :crisis_events, only: :show do
-        get 'page/:page_number', action: :index, on: :collection, as: :pages
+      resources :crisis_events, only: %i[index show] do
         get 'active', action: 'active', on: :collection
         put 'close', action: 'close', on: :member, as: :close
         post 'note', action: 'add_note', on: :member, as: :notes
       end
 
       resources :wba_team_members, only: :show
-
-      resources :journal_entries, only: :show do
-        get 'page/:page_number', action: :index, on: :collection
-      end
+      resources :journal_entries, only: %i[show index]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,7 @@ Rails.application.routes.draw do
 
       resources :wba_selves, only: %i[show new create]
 
-      resources :journal_entries, only: %i[new create] do
-        get 'page/:page_number', action: :index, on: :collection, as: :pages
+      resources :journal_entries, only: %i[index new create] do
         get 'dashboard', action: :dashboard, on: :collection
 
         resources :journal_entry_permissions, only: %i[new create], as: :permissions


### PR DESCRIPTION
The team member user index view has been updated to include pagination, currently I'm limiting every page to 6 users before the pagniation controls kick in. The upper global stats section (including search) and the pinned users section always stay the same, all that changes as you move is the page index and thus the results shown in the all users section.

<img width="1438" alt="Screenshot 2021-03-23 at 15 50 21" src="https://user-images.githubusercontent.com/6815945/112176103-b7154080-8bef-11eb-9b26-fcf1d38199aa.png">
