### PR TITLE
Journal entry permissions change

### DIFF
--- a/app/controllers/team_members/journal_entries_controller.rb
+++ b/app/controllers/team_members/journal_entries_controller.rb
@@ -12,6 +12,7 @@ module TeamMembers
 
     def resources
       @resources = current_team_member.journal_entries.includes(:user, :journal_entry_view_logs)
+                                      .order(created_at: :desc)
     end
 
     private

--- a/app/controllers/users/journal_entry_permissions_controller.rb
+++ b/app/controllers/users/journal_entry_permissions_controller.rb
@@ -1,8 +1,6 @@
 module Users
   # app/controllers/users/journal_entry_permission_controller.rb
   class JournalEntryPermissionsController < PermissionsController
-    skip_before_action :permissions_required
-
     # GET /journal_entries/:journal_entry_id/journal_entry_permissions/new
     def new
       render 'new'
@@ -12,10 +10,6 @@ module Users
 
     def path
       journal_entries_path
-    end
-
-    def new_path
-      new_journal_entry_permission_path(@model)
     end
 
     def model

--- a/app/controllers/users/permissions_controller.rb
+++ b/app/controllers/users/permissions_controller.rb
@@ -5,9 +5,6 @@ module Users
     before_action :permissions_set, if: -> { @model.permissions.present? }
 
     before_action :permissions_params, only: :create
-    before_action :at_least_one, only: :create, unless: lambda {
-      @team_members.map { |team_member| permissions_params["team_member_#{team_member.id}"] }.include? '1'
-    }
 
     before_action :second_to_last, only: :new
     before_action :last_permissions, only: :new, if: -> { @second_to_last.present? }
@@ -27,10 +24,6 @@ module Users
     end
 
     protected
-
-    def new_path
-      raise 'Subclass has not overridden new path function'
-    end
 
     def path
       raise 'Subclass has not overridden path function'
@@ -54,10 +47,6 @@ module Users
 
     def team_members
       @team_members = TeamMember.all.order(:created_at)
-    end
-
-    def at_least_one
-      redirect_to new_path, alert: 'You must select at least one team member'
     end
 
     def permissions_set

--- a/app/controllers/users/users_application_controller.rb
+++ b/app/controllers/users/users_application_controller.rb
@@ -1,7 +1,7 @@
 module Users
   # app/controllers/users/users_application_controller.rb
   class UsersApplicationController < ApplicationController
-    before_action :authenticate_user!, :permissions_required
+    before_action :authenticate_user!
     before_action :active_crisis_events, :crisis_event, :crisis_types, unless: -> { devise_controller? }
 
     def home
@@ -20,13 +20,6 @@ module Users
 
     def crisis_types
       @crisis_types = CrisisType.all
-    end
-
-    def permissions_required
-      return unless current_user.permissions_required?
-
-      redirect_to new_journal_entry_permission_path(current_user.journal_entries.last),
-                  alert: 'Please specify which team members can view this journal entry'
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,14 +30,6 @@ class User < DeviseRecord
     wba_selves.where(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).order(:id).last
   end
 
-  def permissions_required?
-    last_journal_entry = journal_entries.includes(:journal_entry_permissions).last
-
-    return unless last_journal_entry.present?
-
-    last_journal_entry.journal_entry_permissions.empty?
-  end
-
   # validations
   validates_presence_of :first_name,
                         :last_name,


### PR DESCRIPTION
Removed the requirement that at least one permission needs to be set on a journal entry so users can now submit journal entries only viewable by themselves. Also fixed that journal entries in the team member index were not latest first.