### PR TITLE
IJ-135 add external font import to get rubik working on chromium base…

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <style>@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@800&display=swap');</style>
+
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>


### PR DESCRIPTION
…d browsers

really not sure why this is needed, but it works now ¯\_(ツ)_/¯