### PR TITLE
IJ-87 User Wellbeing History Chart

### DIFF
--- a/app/assets/stylesheets/wellbeing_history_chart.scss
+++ b/app/assets/stylesheets/wellbeing_history_chart.scss
@@ -1,0 +1,6 @@
+@import "variables";
+
+#wellbeing-history-chart-wrapper {
+  margin: 0 0 1.5rem 0;
+  background-color: $grey;
+}

--- a/app/assets/stylesheets/wellbeing_history_chart.scss
+++ b/app/assets/stylesheets/wellbeing_history_chart.scss
@@ -3,4 +3,8 @@
 #wellbeing-history-chart-wrapper {
   margin: 0 0 1.5rem 0;
   background-color: $grey;
+
+  h3 {
+    color: $black;
+  }
 }

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -39,6 +39,13 @@ module TeamMembers
                     notice: @user_pin.decrement ? message('pin successfully moved') : message('pin could not be moved'))
     end
 
+    # GET /users/:user_id/wba_history
+    def wba_history
+      respond_to do |format|
+        format.json { render json: @user.wellbeing_assessment_history.as_json, status: :ok }
+      end
+    end
+
     protected
 
     def resources

--- a/app/javascript/packs/wellbeing_history_chart.js
+++ b/app/javascript/packs/wellbeing_history_chart.js
@@ -49,8 +49,8 @@ fetch(`${location}/wba_history`, {
                         }
                     },
                     ticks: {
-                        min: json.labels[0],
-                        max: json.labels[json.labels.length - 1]
+                        bounds: 'ticks',
+                        source: 'auto'
                     },
                     gridLines: {
                         zeroLineColor: 'gray',

--- a/app/javascript/packs/wellbeing_history_chart.js
+++ b/app/javascript/packs/wellbeing_history_chart.js
@@ -1,0 +1,36 @@
+fetch(`${location}/wba_history`, {
+    headers: {
+        'Content-Type': 'application/json'
+    }
+})
+    .then(data => data.json())
+    .then(json => {
+        const schemeCategory10 = [
+            '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+            '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'
+        ]
+
+        json.datasets.forEach((dataset, index) => {
+            dataset.borderColor = schemeCategory10[index]
+            dataset.backgroundColor = `${schemeCategory10[index]}80`
+            dataset.lineTension = 0
+            dataset.hidden = index > 0
+        })
+
+        const history_chart = document.querySelector('#wellbeing-history-chart')
+        const chart = new Chart(history_chart.getContext('2d'), {
+            type: 'line',
+            data: json,
+            options: {
+                scales: {
+                    yAxes: [{
+                        ticks: {
+                            min: 1,
+                            max: 10,
+                            stepSize: 1
+                        }
+                    }]
+                }
+            }
+        })
+    })

--- a/app/javascript/packs/wellbeing_history_chart.js
+++ b/app/javascript/packs/wellbeing_history_chart.js
@@ -54,10 +54,12 @@ fetch(`${location}/wba_history`, {
                     },
                     gridLines: {
                         zeroLineColor: 'gray',
-                        color: 'gray'
+                        color: 'gray',
+                        z: 1
                     },
                 }],
                 yAxes: [{
+                    offset: true,
                     ticks: {
                         min: 1,
                         max: 10,

--- a/app/javascript/packs/wellbeing_history_chart.js
+++ b/app/javascript/packs/wellbeing_history_chart.js
@@ -18,18 +18,18 @@ fetch(`${location}/wba_history`, {
 })
 .then(data => data.json())
 .then(json => {
-    const schemeCategory10 = [
-        '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
-        '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'
+    const colours = [
+        '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b',
+        '#e377c2', '#7f7f7f', '#bcbd22', '#17becf', '#7570b3'
     ]
 
     json.datasets.forEach((dataset, index) => {
-        dataset.borderColor = schemeCategory10[index]
+        dataset.borderColor = colours[index]
         dataset.lineTension = 0
         dataset.fill = false
         dataset.hidden = index > 0
-        dataset.radius = 10
-        dataset.hoverRadius = 11
+        dataset.radius = 5
+        dataset.hoverRadius = 6
         dataset.pointStyle = 'rectRounded'
     })
 
@@ -53,7 +53,8 @@ fetch(`${location}/wba_history`, {
                         max: json.labels[json.labels.length - 1]
                     },
                     gridLines: {
-                        zeroLineColor: '#A7B5BB'
+                        zeroLineColor: 'gray',
+                        color: 'gray'
                     },
                 }],
                 yAxes: [{

--- a/app/javascript/packs/wellbeing_history_chart.js
+++ b/app/javascript/packs/wellbeing_history_chart.js
@@ -28,10 +28,14 @@ fetch(`${location}/wba_history`, {
         dataset.lineTension = 0
         dataset.fill = false
         dataset.hidden = index > 0
+        dataset.radius = 10
+        dataset.hoverRadius = 11
+        dataset.pointStyle = 'rectRounded'
     })
 
     const history_chart = document.querySelector('#wellbeing-history-chart')
-    const chart = new Chart(history_chart.getContext('2d'), {
+
+    new Chart(history_chart.getContext('2d'), {
         type: 'line',
         data: json,
         options: {
@@ -41,7 +45,7 @@ fetch(`${location}/wba_history`, {
                     time: {
                         tooltipFormat: 'MMMM Do YYYY',
                         displayFormats: {
-                            day: 'L'
+                            day: 'Do MMM YY'
                         }
                     },
                     ticks: {
@@ -50,7 +54,7 @@ fetch(`${location}/wba_history`, {
                     },
                     gridLines: {
                         zeroLineColor: '#A7B5BB'
-                    }
+                    },
                 }],
                 yAxes: [{
                     ticks: {
@@ -67,6 +71,12 @@ fetch(`${location}/wba_history`, {
                         color: scale.map(s => s.colour).reverse()
                     }
                 }]
+            },
+            tooltips: {
+                callbacks: {
+                    label: (tooltipItem, data) =>
+                        `${data.datasets[tooltipItem.datasetIndex].label}: ${scale[tooltipItem.yLabel - 1].description}`
+                }
             }
         }
     })

--- a/app/javascript/packs/wellbeing_history_chart.js
+++ b/app/javascript/packs/wellbeing_history_chart.js
@@ -54,8 +54,7 @@ fetch(`${location}/wba_history`, {
                     },
                     gridLines: {
                         zeroLineColor: 'gray',
-                        color: 'gray',
-                        z: 1
+                        color: 'gray'
                     },
                 }],
                 yAxes: [{

--- a/app/javascript/packs/wellbeing_history_chart.js
+++ b/app/javascript/packs/wellbeing_history_chart.js
@@ -1,36 +1,73 @@
+const scale = [
+    { description: "Abysmal", colour: "#E04444" },
+    { description: "Dreadful", colour: "#E64D52" },
+    { description: "Rubbish", colour: "#E86754" },
+    { description: "Bad", colour: "#EC8754" },
+    { description: "Mediocre", colour: "#F0A656" },
+    { description: "Fine", colour: "#DFC54C" },
+    { description: "Good", colour: "#BFCA48" },
+    { description: "Great", colour: "#9ECB46" },
+    { description: "Superb", colour: "#BFCB43" },
+    { description: "Perfect", colour: "#5DAD3A" }
+]
+
 fetch(`${location}/wba_history`, {
     headers: {
         'Content-Type': 'application/json'
     }
 })
-    .then(data => data.json())
-    .then(json => {
-        const schemeCategory10 = [
-            '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
-            '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'
-        ]
+.then(data => data.json())
+.then(json => {
+    const schemeCategory10 = [
+        '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+        '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'
+    ]
 
-        json.datasets.forEach((dataset, index) => {
-            dataset.borderColor = schemeCategory10[index]
-            dataset.backgroundColor = `${schemeCategory10[index]}80`
-            dataset.lineTension = 0
-            dataset.hidden = index > 0
-        })
-
-        const history_chart = document.querySelector('#wellbeing-history-chart')
-        const chart = new Chart(history_chart.getContext('2d'), {
-            type: 'line',
-            data: json,
-            options: {
-                scales: {
-                    yAxes: [{
-                        ticks: {
-                            min: 1,
-                            max: 10,
-                            stepSize: 1
-                        }
-                    }]
-                }
-            }
-        })
+    json.datasets.forEach((dataset, index) => {
+        dataset.borderColor = schemeCategory10[index]
+        dataset.lineTension = 0
+        dataset.fill = false
+        dataset.hidden = index > 0
     })
+
+    const history_chart = document.querySelector('#wellbeing-history-chart')
+    const chart = new Chart(history_chart.getContext('2d'), {
+        type: 'line',
+        data: json,
+        options: {
+            scales: {
+                xAxes: [{
+                    type: 'time',
+                    time: {
+                        tooltipFormat: 'MMMM Do YYYY',
+                        displayFormats: {
+                            day: 'L'
+                        }
+                    },
+                    ticks: {
+                        min: json.labels[0],
+                        max: json.labels[json.labels.length - 1]
+                    },
+                    gridLines: {
+                        zeroLineColor: '#A7B5BB'
+                    }
+                }],
+                yAxes: [{
+                    ticks: {
+                        min: 1,
+                        max: 10,
+                        stepSize: 1,
+                        padding: 15,
+                        callback: value => scale[value - 1].description
+                    },
+                    gridLines: {
+                        drawBorder: false,
+                        tickMarkLength: 0,
+                        lineWidth: Array(10).fill(10),
+                        color: scale.map(s => s.colour).reverse()
+                    }
+                }]
+            }
+        }
+    })
+})

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < DeviseRecord
   def wellbeing_assessment_history
     history = { labels: [], datasets: [] }
 
-    wellbeing_assessments.includes(:wba_scores).each { |wba| wba.add_to_history(history) }
+    wellbeing_assessments.includes(:wba_scores).order(created_at: :desc).each { |wba| wba.add_to_history(history) }
 
     history
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,14 @@ class User < DeviseRecord
     wellbeing_assessments.where(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).order(:id).last
   end
 
+  def wellbeing_assessment_history
+    history = { labels: [], datasets: [] }
+
+    wellbeing_assessments.includes(:wba_scores).each { |wba| wba.add_to_history(history) }
+
+    history
+  end
+
   # validations
   validates_presence_of :first_name,
                         :last_name,

--- a/app/models/wba_score.rb
+++ b/app/models/wba_score.rb
@@ -2,4 +2,17 @@
 class WbaScore < ApplicationRecord
   belongs_to :wellbeing_assessment
   belongs_to :wellbeing_metric
+
+  # rubocop:disable Metrics/AbcSize
+  def add_to_history(history)
+    existing_dataset = history[:datasets].find { |dataset| dataset[:label] == wellbeing_metric.name }
+
+    padding = ([nil] * ((history[:labels].length - 1) - (existing_dataset.present? ? existing_dataset[:data].length : 0)))
+
+    if existing_dataset.present?
+      existing_dataset[:data].concat(padding.push(value))
+    else
+      history[:datasets].push({ label: wellbeing_metric.name, data: padding.push(value) })
+    end
+  end
 end

--- a/app/models/wba_score.rb
+++ b/app/models/wba_score.rb
@@ -3,16 +3,17 @@ class WbaScore < ApplicationRecord
   belongs_to :wellbeing_assessment
   belongs_to :wellbeing_metric
 
-  # rubocop:disable Metrics/AbcSize
   def add_to_history(history)
     existing_dataset = history[:datasets].find { |dataset| dataset[:label] == wellbeing_metric.name }
 
-    padding = ([nil] * ((history[:labels].length - 1) - (existing_dataset.present? ? existing_dataset[:data].length : 0)))
-
     if existing_dataset.present?
-      existing_dataset[:data].concat(padding.push(value))
+      existing_dataset[:data] << point
     else
-      history[:datasets].push({ label: wellbeing_metric.name, data: padding.push(value) })
+      history[:datasets].push({ label: wellbeing_metric.name, data: [point] })
     end
+  end
+
+  def point
+    { x: created_at, y: value }
   end
 end

--- a/app/models/wellbeing_assessment.rb
+++ b/app/models/wellbeing_assessment.rb
@@ -4,4 +4,10 @@ class WellbeingAssessment < ApplicationRecord
   belongs_to :team_member, optional: true
 
   has_many :wba_scores, foreign_key: :wellbeing_assessment_id
+
+  def add_to_history(history)
+    history[:labels].push(created_at.strftime('%d/%m/%Y'))
+
+    wba_scores.includes(:wellbeing_metric).each { |wba_score| wba_score.add_to_history(history) }
+  end
 end

--- a/app/models/wellbeing_assessment.rb
+++ b/app/models/wellbeing_assessment.rb
@@ -6,8 +6,6 @@ class WellbeingAssessment < ApplicationRecord
   has_many :wba_scores, foreign_key: :wellbeing_assessment_id
 
   def add_to_history(history)
-    history[:labels].push(created_at.strftime('%d/%m/%Y'))
-
     wba_scores.includes(:wellbeing_metric).each { |wba_score| wba_score.add_to_history(history) }
   end
 end

--- a/app/views/team_members/users/_wellbeing_history_chart.html.erb
+++ b/app/views/team_members/users/_wellbeing_history_chart.html.erb
@@ -1,0 +1,7 @@
+<section class="row" id="wellbeing-history-chart-wrapper">
+ <div class="col-12">
+   <canvas id="wellbeing-history-chart"></canvas>
+ </div>
+</section>
+
+<%= javascript_pack_tag 'wellbeing_history_chart' %>

--- a/app/views/team_members/users/_wellbeing_history_chart.html.erb
+++ b/app/views/team_members/users/_wellbeing_history_chart.html.erb
@@ -1,5 +1,6 @@
 <section class="row" id="wellbeing-history-chart-wrapper">
  <div class="col-12">
+   <h3><%= local_assigns[:chart_heading] %></h3>
    <canvas id="wellbeing-history-chart"></canvas>
  </div>
 </section>

--- a/app/views/team_members/users/show.html.erb
+++ b/app/views/team_members/users/show.html.erb
@@ -89,7 +89,7 @@
             <div class="col">
               <% if @wellbeing_assessment.present? %>
                 <%= render 'shared/wellbeing_chart/wrapper', chart_alignment: 'left', height: '250',
-                           show_timestamp: true, chart_heading: "#{@wellbeing_assessment.user.full_name}'s Wellbeing",
+                           show_timestamp: true, chart_heading: "#{@user.full_name}'s Wellbeing",
                            sliders_heading: 'Recorded At', wellbeing_assessment: @wellbeing_assessment %>
               <% end %>
             </div>
@@ -98,7 +98,7 @@
       </div>
     </div>
   </div>
-  <%= render 'wellbeing_history_chart' %>
+  <%= render 'wellbeing_history_chart', chart_heading: "#{@user.full_name}'s Wellbeing History" %>
   <div class="row" id="journal">
     <div class="col-12 col-md-6 mb-4">
       <div class="card h-100">

--- a/app/views/team_members/users/show.html.erb
+++ b/app/views/team_members/users/show.html.erb
@@ -98,6 +98,7 @@
       </div>
     </div>
   </div>
+  <%= render 'wellbeing_history_chart' %>
   <div class="row" id="journal">
     <div class="col-12 col-md-6 mb-4">
       <div class="card h-100">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
         put 'increment', action: 'increment', on: :member, as: :increment
         put 'decrement', action: 'decrement', on: :member, as: :decrement
         put 'unpin', action: 'unpin', on: :member, as: :unpin
+        get 'wba_history', action: 'wba_history', on: :member
         resources :notes, only: :create, as: :add_note
         resources :wellbeing_assessments, only: %i[new create], on: :member
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 require 'faker'
 
 total_user_count = 10
-wellbeing_assessments_for_each_user = 1
+wellbeing_assessments_for_each_user = 30
 journal_entries_for_each_user = 5
 crisis_events_count = 100
 notes_count = 100
@@ -194,7 +194,9 @@ if User.count.zero?
       # puts("Creating Wellbeing Assessment #{wba_count} for user #{user_count}")
 
       wellbeing_assessment = WellbeingAssessment.create!(
-        user: user
+        user: user,
+        created_at: Date.today - (wba_count - 1),
+        updated_at: Date.today - (wba_count - 1)
       )
 
       wellbeing_assessment.update!(team_member_id: rand(1..TeamMember.count)) if (wba_count % 5).zero?
@@ -203,7 +205,9 @@ if User.count.zero?
         WbaScore.create!(
           wellbeing_assessment: wellbeing_assessment,
           wellbeing_metric: wellbeing_metric,
-          value: rand(1..10)
+          value: rand(1..10),
+          created_at: Date.today - (wba_count - 1),
+          updated_at: Date.today - (wba_count - 1)
         )
       end
     end


### PR DESCRIPTION
I've added a new segment to the team member user view which displays a history of the users wellbeing assessments as a line chart with the time series as the x-axis, the score given to the metric as the y-axis and the metric itself represented as a line on this chart.

The team member can view different metrics by toggling them as hidden/shown in the chart legend (the first metric loaded displays on initialisation with the remainder hidden by default).

As our data is randomly generated from the seed the lines we end up with tend to erratically jump across the values, this may end up being representative of how users interpret their wellbeing but my gut feeling is that we're more likely to see gradual changes over time with real data.

<img width="1440" alt="Screenshot 2021-04-08 at 15 36 35" src="https://user-images.githubusercontent.com/6815945/114047104-55a4d100-9881-11eb-9314-282d3e4ff2c6.png">