### PR TITLE
IJ-160 Added a hub contact hours modal to UserNavbar

### DIFF
--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -6,10 +6,6 @@
     border-style: solid;
     border-image: linear-gradient(to bottom, $danger, $warning) 1 100%;
     text-align: center;
-
-    .modal-title {
-
-    }
   }
 
   .modal-body {
@@ -37,5 +33,19 @@
         float: right;
       }
     }
+  }
+}
+
+#contactModal{
+  a{
+    color: blue;
+  }
+
+  .modal-header{
+    border-image: linear-gradient(to bottom, $brand-primary, $grey) 1 100%;
+  }
+
+  .modal-body {
+    border-image: linear-gradient(to top, $brand-primary, $grey) 1 100%;
   }
 }

--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -38,7 +38,7 @@
 
 #contactModal{
   a{
-    color: blue;
+    color: $color-secondary-2-0;
   }
 
   .modal-header{

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <% if current_user && !devise_controller? %>
       <%= render partial: '/modals/crisis_events/new' %>
       <%= render partial: '/modals/crisis_events/existing' %>
+      <%= render partial: '/modals/contact_times/index' %>
     <% end %>
   <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,6 +49,10 @@
             data-mdb-ripple-color="dark"><i class="fab fa-twitter"></i></a>
           <a class="btn btn-link btn-floating btn-lg m-1" href="https://include-uk.com" role="button"
             data-mdb-ripple-color="dark"><i class="fab fa-instagram"></i></a>
+          <a class="btn btn-link btn-floating btn-lg m-1" role="button" data-bs-toggle="modal" data-bs-target="#contactModal"
+             data-mdb-ripple-color="dark">
+            <i class="fas fa-clock"></i>
+          </a>
         </section>
       </div>
       <div class="text-center text-dark p-3" style="background-color: rgba(0, 0, 0, 0.2);">

--- a/app/views/modals/contact_times/_index.html.erb
+++ b/app/views/modals/contact_times/_index.html.erb
@@ -10,7 +10,8 @@
         <p><i class="fas fa-calendar-day"></i> Monday to Friday</p>
         <p><i class="fas fa-phone-volume"></i> 01792814792</p>
 
-        <p> Further details of how to contact us can be <a href="http://include-uk.com/contact-us/">found here</a></p>
+        <p> These are the normal Include Hub opening times. For more up to date information, please check on the
+           <a href="http://include-uk.com/contact-us/">main website</a></p>
 
         <div class="container">
           <div class="row">

--- a/app/views/modals/contact_times/_index.html.erb
+++ b/app/views/modals/contact_times/_index.html.erb
@@ -1,0 +1,24 @@
+<div class="modal fade" id="contactModal" tabindex="-1" aria-labelledby="contactModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="contactModalLabel">Include UK Contact Times</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p><i class="fas fa-clock"></i> 8 am to 6 pm.</p>
+        <p><i class="fas fa-calendar-day"></i> Monday to Friday</p>
+        <p><i class="fas fa-phone-volume"></i> 01792814792</p>
+
+        <p> Further details of how to contact us can be <a href="http://include-uk.com/contact-us/">found here</a></p>
+
+        <div class="container">
+          <div class="row">
+            <div class="col text-center">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -76,6 +76,10 @@
                 <div class="nav-label always-show">SOS</div>
                 <i class="fas fa-exclamation-circle"></i>
               </a>
+              <a class="btn btn-success" data-bs-toggle="modal" data-bs-target="#contactModal">
+                <div class="nav-label">Contact times</div>
+                <i class="fas fa-clock"></i>
+              </a>
             <% end %>
             <%= link_to edit_user_registration_path, class: "btn btn-success" do %>
               <div class="nav-label hide">Edit Profile</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -76,10 +76,6 @@
                 <div class="nav-label always-show">SOS</div>
                 <i class="fas fa-exclamation-circle"></i>
               </a>
-              <a class="btn btn-success" data-bs-toggle="modal" data-bs-target="#contactModal">
-                <div class="nav-label">Contact times</div>
-                <i class="fas fa-clock"></i>
-              </a>
             <% end %>
             <%= link_to edit_user_registration_path, class: "btn btn-success" do %>
               <div class="nav-label hide">Edit Profile</div>


### PR DESCRIPTION
Added a contact hours modal view to the navbar. So users can easily see contact hours of include uk and get access to their contact us page. 

I initially thought this could be in the footer, but let me know any feedback. 🙂
![Screenshot 2021-04-26 at 3 43 28 pm](https://user-images.githubusercontent.com/17786854/116101916-27f3c080-a6a6-11eb-8104-885ff2b646bc.png)
