### PR TITLE
Replaced wba_history route after I accidentally deleted it

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
         put 'decrement', action: 'decrement', on: :member, as: :decrement
         put 'unpin', action: 'unpin', on: :member, as: :unpin
         resources :notes, only: %i[create update show]
-        # post 'update', controller: :notes, action: 'update', as: :update_note, on: :member
+        get 'wba_history', action: 'wba_history', on: :member
         resources :wellbeing_assessments, only: %i[new create index], on: :member
       end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 require 'faker'
 
 total_user_count = 10
-wellbeing_assessments_for_each_user = 20
+wellbeing_assessments_for_each_user = 200
 journal_entries_for_each_user = 5
 contacts_for_each_user = 5
 crisis_events_count = 10


### PR DESCRIPTION
Hotfix: wellbeing history chart was not displaying after I accidentally deleted the route in a previous commit.