### PR TITLE
IJ-121 Add Staff Navbar Items

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -14,8 +14,39 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <% if current_user %>
-        <% unless dashboard_controller? %>
+      <% unless dashboard_controller? %>
+        <% if current_team_member %>
+          <div class="navbar-items">
+            <% if current_team_member.admin? %>
+              <%= link_to team_members_path, class: 'btn btn-nav' do %>
+                <i class="fas fa-users"></i>
+                <div class="nav-label hide">Team Members</div>
+              <% end %>
+            <% end %>
+            <%= link_to users_path, class: 'btn btn-nav' do %>
+              <i class="fas fa-user"></i>
+              <div class="nav-label hide">Users</div>
+            <% end %>
+            <%= link_to '#', class: 'btn btn-nav' do %>
+              <i class="fas fa-chart-line"></i>
+              <div class="nav-label hide">Analytics</div>
+            <% end %>
+            <%= link_to active_crisis_events_path, class: 'btn btn-nav' do %>
+              <i class="fas fa-exclamation-circle"></i>
+              <div class="nav-label hide">Crisis Events</div>
+            <% end %>
+            <%= link_to journal_entries_path, class: 'btn btn-nav' do %>
+              <i class="fas fa-book-open"></i>
+              <div class="nav-label hide">Journal Entries</div>
+            <% end %>
+            <%= link_to wellbeing_assessments_path, class: 'btn btn-nav' do %>
+              <i class="fas fa-heart"></i>
+              <div class="nav-label hide">Wellbeing Assessments</div>
+            <% end %>
+          </div>
+          <% end %>
+
+        <% if current_user %>
           <div class="navbar-items">
             <%= link_to dashboard_journal_entries_path, class: 'btn btn-nav' do %>
               <i class="fas fa-book"></i>

--- a/app/views/team_members/dashboard/show.html.erb
+++ b/app/views/team_members/dashboard/show.html.erb
@@ -9,7 +9,7 @@
           <% end %>
 
           <%= render 'shared/dashboard_btn', path: users_path, icon: 'fa-user', text: 'Users' %>
-          <%= render 'shared/dashboard_btn', path: '/', icon: 'fa-chart-line', text: 'Analytics' %>
+          <%= render 'shared/dashboard_btn', path: '#', icon: 'fa-chart-line', text: 'Analytics' %>
 
           <% unless @admin %>
             <%= render 'shared/dashboard_btn', path: active_crisis_events_path, icon: 'fa-exclamation-circle',


### PR DESCRIPTION
Staff members now have a navbar displayed when they are on a page that isn't the homepage. Admins also have an additional item in the navbar to view the team_members page.