### PR TITLE
If the user has no contacts, then redirect to 'add contact' form

### DIFF
--- a/app/views/users/dashboard/show.html.erb
+++ b/app/views/users/dashboard/show.html.erb
@@ -12,8 +12,14 @@
                      large_text: 'My Needs', text: 'Needs' %>
         </div>
         <div class="row">
-          <%= render 'shared/dashboard_btn', path: contacts_path, icon: 'fa-address-book',
+          <% if current_user.contacts.count.zero? %>
+            <%= render 'shared/dashboard_btn', path: new_contact_path, icon: 'fa-address-book',
                      large_text: 'My Contacts', text: 'Contacts' %>
+          <% else %>
+            <%= render 'shared/dashboard_btn', path: contacts_path, icon: 'fa-address-book',
+                     large_text: 'My Contacts', text: 'Contacts' %>
+          <% end %>
+          
           <%= render 'shared/dashboard_btn', path: '#', icon: 'fa-road',
                      large_text: 'My Journey', text: 'Journey' %>
           <%= render 'shared/dashboard_btn', path: '#', icon: 'fa-info-circle',


### PR DESCRIPTION
### Problem
Error was thrown if contacts button was clicked on dashboard when user has no contacts.

### Solution
If the user has no contacts, they are redirected to the add contact view. Otherwise, they are redirected as normal.