### PR TITLE
Feature - IJ-119 Journal Entry View Logs Sort

### DIFF
--- a/app/assets/stylesheets/journal_entry_view_logs.scss
+++ b/app/assets/stylesheets/journal_entry_view_logs.scss
@@ -2,4 +2,9 @@
   .fa-long-arrow-alt-right {
     font-size: 2.5rem;
   }
+
+  .date-sort-select {
+    width: 240px !important;
+    float: right;
+  }
 }

--- a/app/controllers/team_members/journal_entry_view_logs_controller.rb
+++ b/app/controllers/team_members/journal_entry_view_logs_controller.rb
@@ -8,12 +8,15 @@ module TeamMembers
 
     def resources
       @team_member.journal_entry_view_logs.includes(:user, :journal_entry)
+                  .joins(:journal_entry)
+                  .order(sort)
     end
 
     def search
       @team_member.journal_entry_view_logs.includes(:user, :journal_entry)
-                  .joins(:user)
+                  .joins(:journal_entry)
                   .where(user_search, wildcard_query)
+                  .order(sort)
     end
 
     def team_member
@@ -23,6 +26,21 @@ module TeamMembers
     def subheading_stats
       # TODO: Add stats for team member view logs index
 
+    end
+
+    def sort
+      sort_param = journal_entry_view_logs_params[:sort]
+
+      if %w[created_at_asc created_at_desc viewed_at_asc viewed_at_desc].include?(sort_param)
+        sort_param = sort_param.split('_')
+        { "#{sort_param[0..1].join('_') == 'viewed_at' ? 'created_at' : 'journal_entries.created_at'}": sort_param[2] }
+      else
+        { 'created_at': :desc }
+      end
+    end
+
+    def journal_entry_view_logs_params
+      params.permit(:page, :query, :limit, :sort)
     end
   end
 end

--- a/app/javascript/packs/date_sort.js
+++ b/app/javascript/packs/date_sort.js
@@ -1,0 +1,14 @@
+const date_sort = document.querySelector('.date-sort-select select'),
+      url = new URL(location.href)
+
+date_sort.addEventListener('change', () => {
+    url.searchParams.set('sort', date_sort.value)
+    location.href = url.href
+})
+
+if (url.searchParams.has('sort')) {
+    const sort = url.searchParams.get('sort'),
+          option = date_sort.querySelector(`option[value="${sort}"]`)
+
+    if (option) date_sort.value = sort
+}

--- a/app/views/shared/_pagination_controls.html.erb
+++ b/app/views/shared/_pagination_controls.html.erb
@@ -3,34 +3,40 @@
     <div class="row">
       <div class="col">
         <% unless @page == 1 %>
-          <%= link_to 'Previous', send("#{index}_path", page: @page - 1, limit: params[:limit], query: params[:query]),
+          <%= link_to 'Previous', send("#{index}_path", page: @page - 1, limit: params[:limit], query: params[:query],
+                                       sort: params[:sort]),
                       class: 'btn btn-primary' %>
         <% end %>
       </div>
       <div class="col">
         <% unless @page == 1 %>
-          <%= link_to '1', send("#{index}_path", page: 1, limit: params[:limit], query: params[:query]) %>
+          <%= link_to '1', send("#{index}_path", page: 1, limit: params[:limit], query: params[:query],
+                                sort: params[:sort]) %>
         <% end %>
 
         <% unless @page - 1 <= 1 %>
           <% unless @page - 1 == 2 %> ... <% end %>
-          <%= link_to @page - 1, send("#{index}_path", page: @page - 1, limit: params[:limit], query: params[:query]) %>
+          <%= link_to @page - 1, send("#{index}_path", page: @page - 1, limit: params[:limit], query: params[:query],
+                                      sort: params[:sort]) %>
         <% end %>
 
         <strong><%= @page %></strong>
 
         <% unless  @page == @last_page %>
           <% unless (@page + 1) == @last_page %>
-            <%= link_to @page + 1, send("#{index}_path", page: @page + 1, limit: params[:limit], query: params[:query]) %>
+            <%= link_to @page + 1, send("#{index}_path", page: @page + 1, limit: params[:limit], query: params[:query],
+                                        sort: params[:sort]) %>
             <% unless @page + 1 == @last_page - 1 %> ... <% end %>
           <% end %>
 
-          <%= link_to @last_page, send("#{index}_path", page: @last_page, limit: params[:limit], query: params[:query]) %>
+          <%= link_to @last_page, send("#{index}_path", page: @last_page, limit: params[:limit], query: params[:query],
+                                       sort: params[:sort]) %>
         <% end %>
       </div>
       <div class="col">
         <% unless @page == @last_page %>
-          <%= link_to 'Next', send("#{index}_path", page: @page + 1, limit: params[:limit], query: params[:query]),
+          <%= link_to 'Next', send("#{index}_path", page: @page + 1, limit: params[:limit], query: params[:query],
+                                   sort: params[:sort]),
                       class: 'btn btn-primary' %>
         <% end %>
       </div>

--- a/app/views/team_members/journal_entry_view_logs/index.html.erb
+++ b/app/views/team_members/journal_entry_view_logs/index.html.erb
@@ -6,6 +6,14 @@
       <h3><%= @team_member.full_name %> journal entry view logs (<%= @count %>)</h3>
       <%= render 'shared/search_results', query: params[:query], count: @count %>
       <%= render 'shared/limit', resources_per_page: @resources_per_page %>
+      <div class="input-group date-sort-select mb-3">
+        <select class="form-select">
+          <option value="viewed_at_desc">Viewed At (Descending)</option>
+          <option value="viewed_at_asc">Viewed At (Ascending)</option>
+          <option value="created_at_desc">Created At (Descending)</option>
+          <option value="created_at_asc">Created At (Ascending)</option>
+        </select>
+      </div>
       <table class="table table-dark table-striped">
         <thead>
           <th scope="col">User</th>
@@ -26,3 +34,5 @@
     <%= render 'shared/pagination_controls', index: 'team_member_journal_entry_view_logs' %>
   </section>
 </main>
+
+<%= javascript_pack_tag 'date_sort' %>


### PR DESCRIPTION
Team Member's Journal Entry View Log Index page is now sortable by Created At Ascending/Descending and Viewed At Ascending/Descending.

<img width="1440" alt="Screenshot 2021-05-04 at 12 23 18" src="https://user-images.githubusercontent.com/6815945/116996961-14fb7480-acd4-11eb-850b-b8b36d76a913.png">
