### PR TITLE
Bugfix - IJ-140 - Wellbeing Chart Render

### DIFF
--- a/app/javascript/packs/wellbeing_assessment_chart.js
+++ b/app/javascript/packs/wellbeing_assessment_chart.js
@@ -14,70 +14,65 @@ const wellbeing_charts = document.querySelectorAll('.wellbeing-chart.wrapper'),
       classes = [...Array(10).keys()].map(i => `wba-score__${i+1}`)
 
 wellbeing_charts.forEach(wellbeing_chart_wrapper => {
-    const wellbeing_chart = wellbeing_chart_wrapper.querySelector('.wellbeing-chart')
+    const wellbeing_chart = wellbeing_chart_wrapper.querySelector('.wellbeing-chart'),
+          slider = wellbeing_chart_wrapper.querySelector('.sliders'),
+          labels = slider.querySelectorAll('label'),
+          inputs = slider.querySelectorAll('input[type="range"]')
 
-    if (!wellbeing_chart.classList.contains('chartjs-render-monitor')) {
-        const slider = wellbeing_chart_wrapper.querySelector('.sliders'),
-              labels = slider.querySelectorAll('label'),
-              inputs = slider.querySelectorAll('input[type="range"]')
-
-        const chart = new Chart(wellbeing_chart.getContext('2d'), {
-            type: 'polarArea',
-            data: {
-                datasets: [{
-                    data: [...inputs].map(input => input.value),
-                    backgroundColor: [...inputs].map(input => scale[input.value - 1].colour)
-                }],
-                labels: [...labels].map(label => label.innerText.trim())
+    const chart = new Chart(wellbeing_chart.getContext('2d'), {
+        type: 'polarArea',
+        data: {
+            datasets: [{
+                data: [...inputs].map(input => input.value),
+                backgroundColor: [...inputs].map(input => scale[input.value - 1].colour)
+            }],
+            labels: [...labels].map(label => label.innerText.trim())
+        },
+        options: {
+            elements: {
+                arc: {
+                    borderColor: '#FADE0A'
+                }
             },
-            options: {
-                elements: {
-                    arc: {
-                        borderColor: '#FADE0A'
-                    }
-                },
-                legend: {
+            legend: {
+                display: false
+            },
+            scale: {
+                ticks: {
+                    max: 10,
+                    min: 0,
+                    stepSize: 1,
                     display: false
-                },
-                scale: {
-                    ticks: {
-                        max: 10,
-                        min: 0,
-                        stepSize: 1,
-                        display: false
-                    }
-                },
-                animation: {
-                    animateRotate: false
-                },
-                tooltips: {
-                    callbacks: {
-                        label: function (tooltipItem, data) {
-                            return `${data.labels[tooltipItem.index]}: ${scale[tooltipItem.yLabel - 1].description}`
-                        }
+                }
+            },
+            animation: {
+                animateRotate: false
+            },
+            tooltips: {
+                callbacks: {
+                    label: function (tooltipItem, data) {
+                        return `${data.labels[tooltipItem.index]}: ${scale[tooltipItem.yLabel - 1].description}`
                     }
                 }
             }
-            }),
-            setDescription = function (input) {
-                // The description field is only relevant when a the wellbeing charts sliders are visible.
-                const description = input.closest('.row').querySelector('.description')
-                description.innerText = scale[input.value - 1].description
+        }
+        }),
+        setDescription = function (input) {
+            // The description field is only relevant when a the wellbeing charts sliders are visible.
+            const description = input.closest('.row').querySelector('.description')
+            description.innerText = scale[input.value - 1].description
 
-                description.classList.remove(...classes)
-                description.classList.add(`wba-score__${input.value}`)
-            }
+            description.classList.remove(...classes)
+            description.classList.add(`wba-score__${input.value}`)
+        }
 
-        inputs.forEach((input, index) => {
-            input.addEventListener('change', () => {
-                chart.data.datasets[0].data[index] = input.value
-                chart.data.datasets[0].backgroundColor[index] = scale[input.value - 1].colour
-                setDescription(input)
-
-                chart.update()
-            })
-
+    inputs.forEach((input, index) => {
+        input.addEventListener('change', () => {
+            chart.data.datasets[0].data[index] = input.value
+            chart.data.datasets[0].backgroundColor[index] = scale[input.value - 1].colour
             setDescription(input)
+
+            chart.update()
         })
-    }
+    })
 })

--- a/app/javascript/packs/wellbeing_history_chart.js
+++ b/app/javascript/packs/wellbeing_history_chart.js
@@ -78,51 +78,55 @@ fetch(`${location}/wba_history`, {
         'Content-Type': 'application/json'
     }
 })
-.then(data => data.json())
-.then(json => {
-    json.datasets.forEach((dataset, index) => {
-        const carousel_item = document.createElement('div')
-        carousel_item.classList.add('carousel-item')
-        if (index === 0) carousel_item.classList.add('active')
+    .then(data => data.json())
+    .then(json => {
+        [...chart_wrapper.children].forEach(child => child.remove());
+        [...metric_select.children].forEach(child => child.remove());
+        [...indicators.children].forEach(child => child.remove());
 
-        const canvas = document.createElement('canvas')
-        canvas.classList.add(`wellbeing-history-chart-${index}`)
+        json.datasets.forEach((dataset, index) => {
+            const carousel_item = document.createElement('div')
+            carousel_item.classList.add('carousel-item')
+            if (index === 0) carousel_item.classList.add('active')
 
-        const option = document.createElement('option')
-        option.setAttribute('value', index)
-        option.innerHTML = dataset.label
+            const canvas = document.createElement('canvas')
+            canvas.classList.add(`wellbeing-history-chart-${index}`)
 
-        const indicator = document.createElement('button')
-        indicator.setAttribute('type', 'button')
-        indicator.setAttribute('type', 'button')
-        indicator.dataset.bsTarget = '#wellbeing-history-chart-carousel'
-        indicator.dataset.bsSlideTo = index
-        indicator.dataset.toggle = 'tooltip'
-        indicator.setAttribute('title', dataset.label)
-        if (index === 0) indicator.classList.add('active')
-        if (index === 0) indicator.setAttribute('aria-current', 'true')
-        indicator.setAttribute('aria-label', dataset.label)
+            const option = document.createElement('option')
+            option.setAttribute('value', index)
+            option.innerHTML = dataset.label
 
-        indicators.append(indicator)
-        metric_select.append(option)
-        carousel_item.append(canvas)
-        chart_wrapper.append(carousel_item)
+            const indicator = document.createElement('button')
+            indicator.setAttribute('type', 'button')
+            indicator.setAttribute('type', 'button')
+            indicator.dataset.bsTarget = '#wellbeing-history-chart-carousel'
+            indicator.dataset.bsSlideTo = index
+            indicator.dataset.toggle = 'tooltip'
+            indicator.setAttribute('title', dataset.label)
+            if (index === 0) indicator.classList.add('active')
+            if (index === 0) indicator.setAttribute('aria-current', 'true')
+            indicator.setAttribute('aria-label', dataset.label)
 
-        dataset.borderColor = '#1F77B4'
-        dataset.lineTension = 0
-        dataset.fill = false
-        dataset.radius = 2
-        dataset.hoverRadius = 10
-        dataset.pointStyle = 'rectRounded'
+            indicators.append(indicator)
+            metric_select.append(option)
+            carousel_item.append(canvas)
+            chart_wrapper.append(carousel_item)
 
-        create_chart(canvas, {
-            labels: json.labels,
-            datasets: [dataset]
+            dataset.borderColor = '#1F77B4'
+            dataset.lineTension = 0
+            dataset.fill = false
+            dataset.radius = 2
+            dataset.hoverRadius = 10
+            dataset.pointStyle = 'rectRounded'
+
+            create_chart(canvas, {
+                labels: json.labels,
+                datasets: [dataset]
+            })
         })
-    })
 
-    slide_buttons.forEach(button => button.classList.remove('hidden'))
-})
+        slide_buttons.forEach(button => button.classList.remove('hidden'))
+    })
 
 metric_select.addEventListener('change', e => {
     toggle_active(chart_wrapper, e, '.carousel-item')

--- a/app/views/shared/wellbeing_chart/_description.html.erb
+++ b/app/views/shared/wellbeing_chart/_description.html.erb
@@ -1,0 +1,27 @@
+<div class="description badge rounded-pill wba-score__<%= value %>">
+  <%= case value
+      when 1
+        'Abysmal'
+      when 2
+        'Dreadful'
+      when 3
+        'Rubbish'
+      when 4
+        'Bad'
+      when 5
+        'Mediocre'
+      when 6
+        'Fine'
+      when 7
+        'Good'
+      when 8
+        'Great'
+      when 9
+        'Superb'
+      when 10
+        'Perfect'
+      else
+        'Unknown'
+      end
+  %>
+</div>

--- a/app/views/shared/wellbeing_chart/_sliders.html.erb
+++ b/app/views/shared/wellbeing_chart/_sliders.html.erb
@@ -30,8 +30,8 @@
                                    value: last_score(local_assigns[:last_scores], wellbeing_metric.id)  %>
             </div>
             <div class="col-3 col-sm-3">
-              <div class="description badge rounded-pill wba-score__<%= last_score(local_assigns[:last_scores],
-                                                                                   wellbeing_metric.id) %>"></div>
+              <%= render 'shared/wellbeing_chart/description',
+                         value: last_score(local_assigns[:last_scores], wellbeing_metric.id) %>
             </div>
           </div>
         <% end %>
@@ -51,8 +51,7 @@
             <input type="range" id="<%= "wellbeing_metric_#{score.wellbeing_metric.id}" %>" value="<%= score.value %>">
           </div>
           <div class="col-4">
-            <div class="description badge rounded-pill wba-score__<%= last_score(local_assigns[:last_scores],
-                                                                                 score.wellbeing_metric.id) %>"></div>
+            <%= render 'shared/wellbeing_chart/description', value: score.value %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
Fixed a bug with the wellbeing charts not getting re-rendered, this was due to a constraint placed on the JS to not re-run when the `chartjs-render-monitor` class was detected which was necessary as otherwise the chart was being drawn twice. 

The reason the chart was drawn twice is that the DOM was being manipulated by the JS to setup the description text and colours however this isn't necessary as these values are available to the ERB template so can be set there which meant I could remove the JS constraint and so now browser navigation doesn't prevent re-render and the charts animate smoothly. (This was painfully simple code-wise but I was pursuing all sorts of false leads around browser caching and had no idea that the DOM manipulation was the cause of the re-running JS so wound up using process of elimination).

I've also fixed a similar bug with the wellbeing history charts, here the old DOM elements were not removed when the browser navigates backwards meaning duplicate DOM elements were being created and event listeners attached, this was much simpler to deduce and fix as we just need to clear the old DOM elements before inserting the new ones.