### PR TITLE
Feature/IJ-173 Restructure Journal Entry View Logs

### DIFF
--- a/app/controllers/team_members/journal_entries_controller.rb
+++ b/app/controllers/team_members/journal_entries_controller.rb
@@ -6,7 +6,7 @@ module TeamMembers
     # GET /journal_entries/:id
     def show
       journal_entry
-      view_log
+      log_view
 
       render 'show'
     end
@@ -15,7 +15,7 @@ module TeamMembers
 
     def resources
       if journal_entry_params[:feeling].present? || journal_entry_params[:viewed].present?
-        current_team_member.journal_entries.includes(:user, :journal_entry_view_logs)
+        current_team_member.journal_entries.includes(:user)
                            .joins(:user)
                            .where(journal_entry_search(''), query_terms({}))
                            .order(created_at: :desc)
@@ -26,7 +26,7 @@ module TeamMembers
     end
 
     def search
-      current_team_member.journal_entries.includes(:user, :journal_entry_view_logs)
+      current_team_member.journal_entries.includes(:user)
                          .joins(:user)
                          .where(journal_entry_search("(#{user_search})"), query_terms(wildcard_query))
                          .order(created_at: :desc)
@@ -41,9 +41,12 @@ module TeamMembers
                     alert: "That journal entry doesn't exist or you do not have permission to view it")
     end
 
-    def view_log
-      return if current_team_member.journal_entry_view_logs.create!({ journal_entry: @journal_entry })
-
+    def log_view
+      view_log = current_team_member.journal_entry_view_logs.find_or_create_by!(journal_entry: @journal_entry)
+      view_log.increment_view_count
+      view_log.save!
+      debugger
+    rescue ActiveRecord::RecordInvalid
       redirect_back(fallback_location: authenticated_team_member_root_path, alert: 'View log could not be created')
     end
 

--- a/app/controllers/team_members/journal_entries_controller.rb
+++ b/app/controllers/team_members/journal_entries_controller.rb
@@ -45,7 +45,6 @@ module TeamMembers
       view_log = current_team_member.journal_entry_view_logs.find_or_create_by!(journal_entry: @journal_entry)
       view_log.increment_view_count
       view_log.save!
-      debugger
     rescue ActiveRecord::RecordInvalid
       redirect_back(fallback_location: authenticated_team_member_root_path, alert: 'View log could not be created')
     end

--- a/app/controllers/team_members/journal_entry_view_logs_controller.rb
+++ b/app/controllers/team_members/journal_entry_view_logs_controller.rb
@@ -20,15 +20,20 @@ module TeamMembers
     end
 
     def subheading_stats
-      # TODO: Add stats for team member view logs index
+      @viewed_in_last_week = @resources.viewed_in_last_week.size
+      @viewed_in_last_month = @resources.viewed_in_last_month.size
     end
 
     def sort
       sort_param = journal_entry_view_logs_params[:sort]
 
-      if %w[created_at_asc created_at_desc viewed_at_asc viewed_at_desc].include?(sort_param)
+      if %w[created_at_asc created_at_desc viewed_at_asc viewed_at_desc published_at_asc published_at_desc].include?(sort_param)
         sort_param = sort_param.split('_')
-        { "#{sort_param[0..1].join('_') == 'viewed_at' ? 'updated_at' : 'created_at'}": sort_param[2] }
+        sort_order = sort_param[2]
+        sort_param = sort_param[0..1].join('_')
+        sort_param = sort_param == 'published_at' ? 'journal_entries.created_at' : "journal_entry_view_logs.#{sort_param}"
+
+        { "#{sort_param}": sort_order }
       else
         { 'updated_at': :desc }
       end

--- a/app/controllers/team_members/journal_entry_view_logs_controller.rb
+++ b/app/controllers/team_members/journal_entry_view_logs_controller.rb
@@ -19,10 +19,6 @@ module TeamMembers
                   .order(sort)
     end
 
-    def team_member
-      @team_member = TeamMember.includes(:journal_entry_view_logs).find(params[:team_member_id])
-    end
-
     def subheading_stats
       # TODO: Add stats for team member view logs index
 
@@ -37,6 +33,12 @@ module TeamMembers
       else
         { 'created_at': :desc }
       end
+    end
+
+    private
+
+    def team_member
+      @team_member = TeamMember.includes(:journal_entry_view_logs).find(params[:team_member_id])
     end
 
     def journal_entry_view_logs_params

--- a/app/controllers/team_members/journal_entry_view_logs_controller.rb
+++ b/app/controllers/team_members/journal_entry_view_logs_controller.rb
@@ -21,7 +21,6 @@ module TeamMembers
 
     def subheading_stats
       # TODO: Add stats for team member view logs index
-
     end
 
     def sort
@@ -29,9 +28,9 @@ module TeamMembers
 
       if %w[created_at_asc created_at_desc viewed_at_asc viewed_at_desc].include?(sort_param)
         sort_param = sort_param.split('_')
-        { "#{sort_param[0..1].join('_') == 'viewed_at' ? 'created_at' : 'journal_entries.created_at'}": sort_param[2] }
+        { "#{sort_param[0..1].join('_') == 'viewed_at' ? 'updated_at' : 'created_at'}": sort_param[2] }
       else
-        { 'created_at': :desc }
+        { 'updated_at': :desc }
       end
     end
 

--- a/app/controllers/team_members/user_profile_view_logs_controller.rb
+++ b/app/controllers/team_members/user_profile_view_logs_controller.rb
@@ -30,7 +30,7 @@ module TeamMembers
         sort_param = sort_param.split('_')
         { "#{sort_param[0..1].join('_') == 'viewed_at' ? 'updated_at' : 'created_at'}": sort_param[2] }
       else
-        { 'created_at': :desc }
+        { 'updated_at': :desc }
       end
     end
 

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -83,7 +83,9 @@ module TeamMembers
     private
 
     def log_view
-      current_team_member.user_profile_view_logs.find_or_create_by!(user: @user)
+      view_log = current_team_member.user_profile_view_logs.find_or_create_by!(user: @user)
+      view_log.increment_view_count
+      view_log.save!
     rescue ActiveRecord::RecordInvalid
       redirect_back(fallback_location: authenticated_team_member_root_path, alert: 'View log could not be created')
     end

--- a/app/models/journal_entry_view_log.rb
+++ b/app/models/journal_entry_view_log.rb
@@ -1,7 +1,15 @@
 # app/models/journal_entry_view_log.rb
 class JournalEntryViewLog < ApplicationRecord
-  belongs_to :journal_entry
+  after_initialize :increment_view_count
+
   belongs_to :team_member
+  belongs_to :journal_entry
 
   has_one :user, through: :journal_entry
+
+  validates_presence_of :team_member_id, :journal_entry_id
+
+  def increment_view_count
+    self.view_count += 1
+  end
 end

--- a/app/models/journal_entry_view_log.rb
+++ b/app/models/journal_entry_view_log.rb
@@ -2,8 +2,10 @@
 class JournalEntryViewLog < ApplicationRecord
   belongs_to :team_member
   belongs_to :journal_entry
-
   has_one :user, through: :journal_entry
+
+  scope :viewed_in_last_week, -> { where('journal_entry_view_logs.updated_at >= ?', 1.week.ago) }
+  scope :viewed_in_last_month, -> { where('journal_entry_view_logs.updated_at >= ?', 1.month.ago) }
 
   validates_presence_of :team_member_id, :journal_entry_id
 

--- a/app/models/journal_entry_view_log.rb
+++ b/app/models/journal_entry_view_log.rb
@@ -1,7 +1,5 @@
 # app/models/journal_entry_view_log.rb
 class JournalEntryViewLog < ApplicationRecord
-  after_initialize :increment_view_count
-
   belongs_to :team_member
   belongs_to :journal_entry
 

--- a/app/models/user_profile_view_log.rb
+++ b/app/models/user_profile_view_log.rb
@@ -1,7 +1,5 @@
 # app/models/user_profile_view_log.rb
 class UserProfileViewLog < ApplicationRecord
-  after_initialize :increment_view_count
-
   belongs_to :team_member
   belongs_to :user
 

--- a/app/views/team_members/journal_entry_view_logs/_stats.html.erb
+++ b/app/views/team_members/journal_entry_view_logs/_stats.html.erb
@@ -1,0 +1,4 @@
+<div class="subheading">
+  <p><%= @team_member.first_name %> has viewed <%= pluralize(@viewed_in_last_week, 'journal entry', 'journal entries') %>
+  in the last week and <%= pluralize(@viewed_in_last_month, 'journal entry', 'journal entries') %> in the last month.</p>
+</div>

--- a/app/views/team_members/journal_entry_view_logs/index.html.erb
+++ b/app/views/team_members/journal_entry_view_logs/index.html.erb
@@ -20,15 +20,22 @@
         <table class="table table-dark table-striped">
           <thead>
           <th scope="col">User</th>
-          <th scope="col">Created At</th>
-          <th scope="col">Viewed At</th>
+          <th scope="col">Journal Entry</th>
+          <th scope="col">Published at</th>
+          <th scope="col">First Viewed At</th>
+          <th scope="col">Last Viewed At</th>
+          <th scope="col">View Count</th>
+
           </thead>
           <tbody>
           <% @resources.each do |view_log| %>
             <tr>
               <td><%= view_log.user.full_name %></td>
+              <td><%= journal_entry_path(view_log.journal_entry) %></td>
               <td><%= view_log.journal_entry.created %></td>
+              <td><%= view_log.created %></td>
               <td><%= view_log.created %>
+              <td><%= view_log.view_count %></td>
             </tr>
           <% end %>
           </tbody>

--- a/app/views/team_members/journal_entry_view_logs/index.html.erb
+++ b/app/views/team_members/journal_entry_view_logs/index.html.erb
@@ -20,22 +20,26 @@
         <table class="table table-dark table-striped">
           <thead>
           <th scope="col">User</th>
-          <th scope="col">Journal Entry</th>
           <th scope="col">Published at</th>
           <th scope="col">First Viewed At</th>
           <th scope="col">Last Viewed At</th>
           <th scope="col">View Count</th>
+          <th scope="col">Journal Entry</th>
 
           </thead>
           <tbody>
           <% @resources.each do |view_log| %>
             <tr>
               <td><%= view_log.user.full_name %></td>
-              <td><%= journal_entry_path(view_log.journal_entry) %></td>
               <td><%= view_log.journal_entry.created %></td>
               <td><%= view_log.created %></td>
-              <td><%= view_log.created %>
+              <td><%= view_log.last_update %>
               <td><%= view_log.view_count %></td>
+              <td>
+                <%= link_to journal_entry_path(view_log.journal_entry) do %>
+                  <i class="fas fa-external-link-alt ms-2" data-toggle="tooltip" data-placement="bottom" title="View History"></i>
+                <% end %>
+              </td>
             </tr>
           <% end %>
           </tbody>

--- a/app/views/team_members/journal_entry_view_logs/index.html.erb
+++ b/app/views/team_members/journal_entry_view_logs/index.html.erb
@@ -7,10 +7,10 @@
       <div class="col">
         <div class="input-group date-sort-select">
           <select class="form-select">
-            <option value="viewed_at_desc">Viewed At (Descending)</option>
-            <option value="viewed_at_asc">Viewed At (Ascending)</option>
-            <option value="created_at_desc">Created At (Descending)</option>
-            <option value="created_at_asc">Created At (Ascending)</option>
+            <option value="viewed_at_desc">Last Viewed At (Descending)</option>
+            <option value="viewed_at_asc">Last Viewed At (Ascending)</option>
+            <option value="created_at_desc">First Viewed At (Descending)</option>
+            <option value="created_at_asc">First Viewed At (Ascending)</option>
           </select>
         </div>
       </div>

--- a/app/views/team_members/journal_entry_view_logs/index.html.erb
+++ b/app/views/team_members/journal_entry_view_logs/index.html.erb
@@ -1,16 +1,18 @@
 <%= render 'layouts/searchable', class_list: 'team-members journal-entry-view-logs',
            header: "#{@team_member.full_name}",
            subheader: "journal entry view logs (#{@count})",
-           index: 'team_member_journal_entry_view_logs' do %>
+           index: 'team_member_journal_entry_view_logs', stats: render(partial: 'stats') do %>
   <div class="container p-0">
     <div class="row mb-3">
       <div class="col">
         <div class="input-group date-sort-select">
           <select class="form-select">
-            <option value="viewed_at_desc">Last Viewed At (Descending)</option>
-            <option value="viewed_at_asc">Last Viewed At (Ascending)</option>
+            <option value="updated_at_desc">Last Viewed At (Descending)</option>
+            <option value="updated_at_asc">Last Viewed At (Ascending)</option>
             <option value="created_at_desc">First Viewed At (Descending)</option>
             <option value="created_at_asc">First Viewed At (Ascending)</option>
+            <option value="published_at_desc">Published At (Descending)</option>
+            <option value="published_at_asc">Published At (Ascending)</option>
           </select>
         </div>
       </div>
@@ -19,13 +21,12 @@
       <div class="col">
         <table class="table table-dark table-striped">
           <thead>
-          <th scope="col">User</th>
-          <th scope="col">Published at</th>
-          <th scope="col">First Viewed At</th>
-          <th scope="col">Last Viewed At</th>
-          <th scope="col">View Count</th>
-          <th scope="col">Journal Entry</th>
-
+            <th scope="col">User</th>
+            <th scope="col">Published at</th>
+            <th scope="col">First Viewed At</th>
+            <th scope="col">Last Viewed At</th>
+            <th scope="col">View Count</th>
+            <th scope="col">Journal Entry</th>
           </thead>
           <tbody>
           <% @resources.each do |view_log| %>
@@ -37,7 +38,8 @@
               <td><%= view_log.view_count %></td>
               <td>
                 <%= link_to journal_entry_path(view_log.journal_entry) do %>
-                  <i class="fas fa-external-link-alt ms-2" data-toggle="tooltip" data-placement="bottom" title="View History"></i>
+                  <i class="fas fa-external-link-alt ms-2" data-toggle="tooltip" data-placement="bottom"
+                     title="View Journal Entry"></i>
                 <% end %>
               </td>
             </tr>

--- a/app/views/team_members/user_profile_view_logs/index.html.erb
+++ b/app/views/team_members/user_profile_view_logs/index.html.erb
@@ -6,10 +6,10 @@
       <div class="col">
         <div class="input-group date-sort-select">
           <select class="form-select">
-            <option value="created_at_desc">First Viewed At (Descending)</option>
-            <option value="created_at_asc">First Viewed At (Ascending)</option>
             <option value="viewed_at_desc">Last Viewed At (Descending)</option>
             <option value="viewed_at_asc">Last Viewed At (Ascending)</option>
+            <option value="created_at_desc">First Viewed At (Descending)</option>
+            <option value="created_at_asc">First Viewed At (Ascending)</option>
           </select>
         </div>
       </div>

--- a/db/migrate/20210225225119_create_journal_entry_view_logs.rb
+++ b/db/migrate/20210225225119_create_journal_entry_view_logs.rb
@@ -2,8 +2,9 @@
 class CreateJournalEntryViewLogs < ActiveRecord::Migration[6.1]
   def change
     create_table :journal_entry_view_logs do |t|
-      t.belongs_to :journal_entry, null: false, foreign_key: true
       t.belongs_to :team_member, null: false, foreign_key: true
+      t.belongs_to :journal_entry, null: false, foreign_key: true
+      t.integer :view_count, default: 0
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -116,8 +116,9 @@ ActiveRecord::Schema.define(version: 2021_05_05_111437) do
   end
 
   create_table "journal_entry_view_logs", force: :cascade do |t|
-    t.bigint "journal_entry_id", null: false
     t.bigint "team_member_id", null: false
+    t.bigint "journal_entry_id", null: false
+    t.integer "view_count", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["journal_entry_id"], name: "index_journal_entry_view_logs_on_journal_entry_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -329,7 +329,9 @@ if User.count.zero?
         JournalEntryViewLog.create!(
           team_member: team_member,
           journal_entry: journal_entry,
-          created_at: created_at_value + 1.day
+          created_at: DateTime.now - rand(60...480).minutes,
+          updated_at: DateTime.now - rand(1...60).minutes,
+          view_count: rand(0..10)
         )
       end
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -258,15 +258,15 @@ if User.count.zero?
     user.save!
 
     ## Create a view log for every user
-    TeamMember.all.each do |team_member|
-      UserProfileViewLog.create!(
-        team_member: team_member,
-        user: user,
-        created_at: DateTime.now - rand(60...480).minutes,
-        updated_at: DateTime.now - rand(1...60).minutes,
-        view_count: rand(0..10)
-      )
-    end
+    # TeamMember.all.each do |team_member|
+    #   UserProfileViewLog.create!(
+    #     team_member: team_member,
+    #     user: user,
+    #     created_at: DateTime.now - rand(60...480).minutes,
+    #     updated_at: DateTime.now - rand(1...60).minutes,
+    #     view_count: rand(0..10)
+    #   )
+    # end
 
     ## Create User Wellbeing Assessments for each user
     user_wba_counter = 0

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -258,15 +258,15 @@ if User.count.zero?
     user.save!
 
     ## Create a view log for every user
-    # TeamMember.all.each do |team_member|
-    #   UserProfileViewLog.create!(
-    #     team_member: team_member,
-    #     user: user,
-    #     created_at: DateTime.now - rand(60...480).minutes,
-    #     updated_at: DateTime.now - rand(1...60).minutes,
-    #     view_count: rand(0..10)
-    #   )
-    # end
+    TeamMember.all.each do |team_member|
+      UserProfileViewLog.create!(
+        team_member: team_member,
+        user: user,
+        created_at: DateTime.now - rand(60...480).minutes,
+        updated_at: DateTime.now - rand(1...60).minutes,
+        view_count: rand(0..10)
+      )
+    end
 
     ## Create User Wellbeing Assessments for each user
     user_wba_counter = 0
@@ -323,18 +323,18 @@ if User.count.zero?
       end
 
       ## Create View Log for every 7th journal entry
-      # next unless (journal_counter % 7).zero?
+      next unless (journal_counter % 7).zero?
 
-      # TeamMember.all.each do |team_member|
-      #   view_log_created_at = Faker::Time.between(from: created_at_value, to: DateTime.now)
-      #   JournalEntryViewLog.create!(
-      #     team_member: team_member,
-      #     journal_entry: journal_entry,
-      #     created_at: view_log_created_at,
-      #     updated_at: Faker::Time.between(from: view_log_created_at, to: DateTime.now),
-      #     view_count: rand(0..10)
-      #   )
-      # end
+      TeamMember.all.each do |team_member|
+        view_log_created_at = Faker::Time.between(from: created_at_value, to: DateTime.now)
+        JournalEntryViewLog.create!(
+          team_member: team_member,
+          journal_entry: journal_entry,
+          created_at: view_log_created_at,
+          updated_at: Faker::Time.between(from: view_log_created_at, to: DateTime.now),
+          view_count: rand(0..10)
+        )
+      end
     end
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -326,11 +326,12 @@ if User.count.zero?
       next unless (journal_counter % 7).zero?
 
       TeamMember.all.each do |team_member|
+        view_log_created_at = Faker::Time.between(from: created_at_value, to: DateTime.now)
         JournalEntryViewLog.create!(
           team_member: team_member,
           journal_entry: journal_entry,
-          created_at: DateTime.now - rand(60...480).minutes,
-          updated_at: DateTime.now - rand(1...60).minutes,
+          created_at: view_log_created_at,
+          updated_at: Faker::Time.between(from: view_log_created_at, to: DateTime.now),
           view_count: rand(0..10)
         )
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -323,18 +323,18 @@ if User.count.zero?
       end
 
       ## Create View Log for every 7th journal entry
-      next unless (journal_counter % 7).zero?
+      # next unless (journal_counter % 7).zero?
 
-      TeamMember.all.each do |team_member|
-        view_log_created_at = Faker::Time.between(from: created_at_value, to: DateTime.now)
-        JournalEntryViewLog.create!(
-          team_member: team_member,
-          journal_entry: journal_entry,
-          created_at: view_log_created_at,
-          updated_at: Faker::Time.between(from: view_log_created_at, to: DateTime.now),
-          view_count: rand(0..10)
-        )
-      end
+      # TeamMember.all.each do |team_member|
+      #   view_log_created_at = Faker::Time.between(from: created_at_value, to: DateTime.now)
+      #   JournalEntryViewLog.create!(
+      #     team_member: team_member,
+      #     journal_entry: journal_entry,
+      #     created_at: view_log_created_at,
+      #     updated_at: Faker::Time.between(from: view_log_created_at, to: DateTime.now),
+      #     view_count: rand(0..10)
+      #   )
+      # end
     end
 
 


### PR DESCRIPTION
Restructured `JournalEntryViewLogs`, in a similar way to the behaviour of `UserProfileViewLogs`. Before, if the user refreshes the page repeatedly it would create a new view log for each view, which would eventually bloat the database. Instead, we create a single view log, with a `view count`, and just increment the `view count`.

![Screenshot from 2021-05-13 16-02-20](https://user-images.githubusercontent.com/24230549/118144669-9eadef00-b404-11eb-93f6-3f132bb39405.png)

While doing this ticket I noticed an error with updating the view count that was also happening in `UserProfileViewLogs`, so I fixed that - hence so many commits and file changes.