### PR TITLE
Feature - IJ-190 Export Wellbeing Assessments

### DIFF
--- a/app/controllers/concerns/exportable.rb
+++ b/app/controllers/concerns/exportable.rb
@@ -1,0 +1,45 @@
+# app/controllers/concerns/exportable.rb
+module Exportable
+  extend ActiveSupport::Concern
+  require 'csv'
+  included do
+    before_action :exportable, only: :export
+  end
+
+  protected
+
+  def exportable
+    @query = exportable_params[:query]
+    @resources = @query.present? ? search : resources
+
+    respond_to do |format|
+      format.csv { send_data to_csv, filename: filename('csv') }
+    end
+  end
+
+  def to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << csv_headers
+
+      @resources.each do |resource|
+        csv << resource.to_csv
+      end
+    end
+  end
+
+  def csv_headers
+    raise 'CSV Headers not overridden'
+  end
+
+  def base_path
+    raise 'Base path not overridden'
+  end
+
+  def filename(type)
+    "#{base_path}-#{DateTime.now.strftime('%Y-%m-%d-%H-%M-%S')}.#{type}"
+  end
+
+  def exportable_params
+    params.permit(:query)
+  end
+end

--- a/app/controllers/concerns/exportable.rb
+++ b/app/controllers/concerns/exportable.rb
@@ -2,6 +2,7 @@
 module Exportable
   extend ActiveSupport::Concern
   require 'csv'
+  require 'json'
   included do
     before_action :exportable, only: :export
   end
@@ -13,6 +14,7 @@ module Exportable
     @resources = @query.present? ? search : resources
 
     respond_to do |format|
+      format.json { send_data @resources.map(&:json).to_json, filename: filename('json') }
       format.csv { send_data to_csv, filename: filename('csv') }
     end
   end

--- a/app/controllers/team_members/wellbeing_assessments_controller.rb
+++ b/app/controllers/team_members/wellbeing_assessments_controller.rb
@@ -64,7 +64,8 @@ module TeamMembers
     end
 
     def csv_headers
-      ['ID', 'Date', 'User ID', 'User Name', 'Team Member ID', 'Team Member Name'] + WellbeingMetric.all.order(:id).map(&:name)
+      ['ID', 'Date', 'User ID', 'User Name', 'User Sex', 'User Gender Identity', 'User Ethnic Group',
+       'User Disabilities', 'User Tags', 'Team Member ID', 'Team Member Name'] + WellbeingMetric.all.order(:id).map(&:name)
     end
 
     def base_path

--- a/app/controllers/team_members/wellbeing_assessments_controller.rb
+++ b/app/controllers/team_members/wellbeing_assessments_controller.rb
@@ -64,8 +64,9 @@ module TeamMembers
     end
 
     def csv_headers
-      ['ID', 'Date', 'User ID', 'User Name', 'User Sex', 'User Gender Identity', 'User Ethnic Group',
-       'User Disabilities', 'User Tags', 'Team Member ID', 'Team Member Name'] + WellbeingMetric.all.order(:id).map(&:name)
+      ['ID', 'Date', 'User ID', 'User Name', 'User Date Of Birth', 'User Release Date', 'User Sex',
+       'User Gender Identity', 'User Ethnic Group', 'User Disabilities', 'User Tags', 'Team Member ID',
+       'Team Member Name'] + WellbeingMetric.all.order(:id).map(&:name)
     end
 
     def base_path

--- a/app/controllers/team_members/wellbeing_assessments_controller.rb
+++ b/app/controllers/team_members/wellbeing_assessments_controller.rb
@@ -2,8 +2,10 @@ module TeamMembers
   # app/controllers/team_members/wellbeing_assessments_controller.rb
   class WellbeingAssessmentsController < TeamMembersApplicationController
     before_action :user, except: :show
-    before_action :team_member, :wellbeing_assessments, :wba_values, only: :index
+    before_action :wba_values, only: :index
+    before_action :team_member, :wellbeing_assessments, only: %i[index export]
     include Pagination
+    include Exportable
 
     before_action :wellbeing_metrics, only: %i[new create]
     before_action :wba_params, only: :create
@@ -13,6 +15,11 @@ module TeamMembers
     # GET /team_members/:team_member_id/wellbeing_assessments
     # GET /users/:user_id/wellbeing_assessments
     def index; end
+
+    # GET /wellbeing_assessments/export
+    # GET /team_members/:team_member_id/wellbeing_assessments/export
+    # GET /users/:user_id/wellbeing_assessments/export
+    def export; end
 
     # GET /wellbeing_assessments/:id
     def show
@@ -43,7 +50,7 @@ module TeamMembers
     protected
 
     def resources
-      @wellbeing_assessments.includes(:user, :wba_scores).order(created_at: :desc)
+      @wellbeing_assessments.order(created_at: :desc)
     end
 
     def resources_per_page
@@ -51,10 +58,17 @@ module TeamMembers
     end
 
     def search
-      @wellbeing_assessments.includes(:user, :wba_scores)
-                            .joins(:user)
+      @wellbeing_assessments.joins(:user)
                             .where(user_search, wildcard_query)
                             .order(created_at: :desc)
+    end
+
+    def csv_headers
+      ['ID', 'Date', 'User ID', 'User Name', 'Team Member ID', 'Team Member Name'] + WellbeingMetric.all.order(:id).map(&:name)
+    end
+
+    def base_path
+      'wellbeing-assessments'
     end
 
     private
@@ -109,11 +123,11 @@ module TeamMembers
     def wellbeing_assessments
       @wellbeing_assessments =
         if @team_member.present?
-          @team_member.wellbeing_assessments
+          @team_member.wellbeing_assessments.includes(:user, wba_scores: :wellbeing_metric)
         elsif @user.present?
           @user.wellbeing_assessments.includes(:team_member, wba_scores: :wellbeing_metric)
         else
-          WellbeingAssessment
+          WellbeingAssessment.includes(:user, :team_member, wba_scores: :wellbeing_metric)
         end
     end
 

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -33,6 +33,17 @@ class TeamMember < DeviseRecord
     (journal_entries.where(user: user) - viewed_journal_entries.where(user: user)).count
   end
 
+  def to_csv
+    [id, full_name]
+  end
+
+  def json
+    {
+      'ID': id,
+      'Name': full_name
+    }
+  end
+
   # validations
   validates_presence_of :first_name,
                         :last_name,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,11 @@ class User < DeviseRecord
   scope :active_last_month, -> { where('current_sign_in_at >= ?', 1.month.ago) }
 
   def release
-    release_date.present? ? release_date.strftime('%d/%m/%Y') : 'Unknown Release Date'
+    release_date.present? ? release_date.strftime('%d/%m/%Y') : ''
+  end
+
+  def dob
+    date_of_birth.present? ? date_of_birth.strftime('%d/%m/%Y') : ''
   end
 
   def active_crisis_events
@@ -60,10 +64,13 @@ class User < DeviseRecord
     appointments.order(start: :asc).filter(&:last_month)
   end
 
+  # rubocop:disable Metrics/MethodLength
   def to_csv
     [
       id,
       full_name,
+      dob,
+      release,
       sex,
       gender_identity,
       ethnic_group,
@@ -76,6 +83,8 @@ class User < DeviseRecord
     {
       'ID': id,
       'Name': full_name,
+      'Date Of Birth': dob,
+      'Release Date': release,
       'Sex': sex,
       'Gender Identity': gender_identity,
       'Ethnic Group': ethnic_group,
@@ -83,6 +92,7 @@ class User < DeviseRecord
       'Tags': user_tags.map { |user_tag| user_tag.tag.tag }.join(', ')
     }
   end
+  # rubocop:enable Metrics/MethodLength
 
   # validations
   validates_presence_of :first_name,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,30 @@ class User < DeviseRecord
     appointments.order(start: :asc).filter(&:last_month)
   end
 
+  def to_csv
+    [
+      id,
+      full_name,
+      sex,
+      gender_identity,
+      ethnic_group,
+      disabilities,
+      user_tags.map { |user_tag| user_tag.tag.tag }.join(', ')
+    ]
+  end
+
+  def json
+    {
+      'ID': id,
+      'Name': full_name,
+      'Sex': sex,
+      'Gender Identity': gender_identity,
+      'Ethnic Group': ethnic_group,
+      'Disabilities': disabilities,
+      'Tags': user_tags.map { |user_tag| user_tag.tag.tag }.join(', ')
+    }
+  end
+
   # validations
   validates_presence_of :first_name,
                         :last_name,

--- a/app/models/wellbeing_assessment.rb
+++ b/app/models/wellbeing_assessment.rb
@@ -11,26 +11,19 @@ class WellbeingAssessment < ApplicationRecord
 
   # rubocop:disable Metrics/AbcSize
   def to_csv
-    [
-      id,
-      created,
-      user.id,
-      user.full_name,
-      team_member.present? ? team_member.id : nil,
-      team_member.present? ? team_member.full_name : nil
-    ] + wba_scores.order(:wellbeing_metric_id).map(&:value)
+    [id, created] + user.to_csv + (team_member.present? ? team_member.to_csv : [nil, nil]) + wba_scores.order(:wellbeing_metric_id).map(&:value)
   end
 
   def json
     {
       'ID': id,
-      'Date': created,
-      'User ID': user.id,
-      'User Name': user.full_name,
-      'Team Member ID': team_member.present? ? team_member.id : nil,
-      'Team Member Name': team_member.present? ? team_member.full_name : nil,
-      'Scores': wba_scores.order(:wellbeing_metric_id).map { |score| { "#{score.wellbeing_metric.name}": score.value } }
+      'Date': created
     }
+      .merge(user.json.transform_keys { |key| "User #{key}" })
+      .merge(team_member.present? ? team_member.json.transform_keys { |key| "Team Member #{key}" } : {})
+      .merge({
+               'Scores': wba_scores.order(:wellbeing_metric_id).map { |score| { "#{score.wellbeing_metric.name}": score.value } }
+             })
   end
   # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/wellbeing_assessment.rb
+++ b/app/models/wellbeing_assessment.rb
@@ -20,5 +20,17 @@ class WellbeingAssessment < ApplicationRecord
       team_member.present? ? team_member.full_name : nil
     ] + wba_scores.order(:wellbeing_metric_id).map(&:value)
   end
+
+  def json
+    {
+      'ID': id,
+      'Date': created,
+      'User ID': user.id,
+      'User Name': user.full_name,
+      'Team Member ID': team_member.present? ? team_member.id : nil,
+      'Team Member Name': team_member.present? ? team_member.full_name : nil,
+      'Scores': wba_scores.order(:wellbeing_metric_id).map { |score| { "#{score.wellbeing_metric.name}": score.value } }
+    }
+  end
   # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/wellbeing_assessment.rb
+++ b/app/models/wellbeing_assessment.rb
@@ -8,4 +8,17 @@ class WellbeingAssessment < ApplicationRecord
   def today?
     created_at.today?
   end
+
+  # rubocop:disable Metrics/AbcSize
+  def to_csv
+    [
+      id,
+      created,
+      user.id,
+      user.full_name,
+      team_member.present? ? team_member.id : nil,
+      team_member.present? ? team_member.full_name : nil
+    ] + wba_scores.order(:wellbeing_metric_id).map(&:value)
+  end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/views/team_members/wellbeing_assessments/_export_btn.html.erb
+++ b/app/views/team_members/wellbeing_assessments/_export_btn.html.erb
@@ -1,0 +1,15 @@
+<% if @user.present? %>
+  <%= link_to export_user_wellbeing_assessments_path(user: @user, format: file_format, query: params[:query]),
+              class: 'btn btn-primary' do %>
+    Export As <%= file_format.capitalize %> <i class="fas fa-file-export"></i>
+  <% end %>
+<% elsif @team_member.present? %>
+  <%= link_to export_team_member_wellbeing_assessments_path(team_member: @team_member, format: file_format,
+                                                            query: params[:query]), class: 'btn btn-primary' do %>
+    Export As <%= file_format.capitalize %> <i class="fas fa-file-export"></i>
+  <% end %>
+<% else %>
+  <%= link_to export_wellbeing_assessments_path(format: file_format, query: params[:query]), class: 'btn btn-primary' do %>
+    Export As <%= file_format.upcase %> <i class="fas fa-file-export"></i>
+  <% end %>
+<% end %>

--- a/app/views/team_members/wellbeing_assessments/_export_btn.html.erb
+++ b/app/views/team_members/wellbeing_assessments/_export_btn.html.erb
@@ -1,6 +1,5 @@
 <% if @user.present? %>
-  <%= link_to export_user_wellbeing_assessments_path(user: @user, format: file_format, query: params[:query]),
-              class: 'btn btn-primary' do %>
+  <%= link_to export_user_wellbeing_assessments_path(user: @user, format: file_format), class: 'btn btn-primary' do %>
     Export As <%= file_format.upcase %> <i class="fas <%= file_format_icon %>"></i>
   <% end %>
 <% elsif @team_member.present? %>

--- a/app/views/team_members/wellbeing_assessments/_export_btn.html.erb
+++ b/app/views/team_members/wellbeing_assessments/_export_btn.html.erb
@@ -1,15 +1,15 @@
 <% if @user.present? %>
   <%= link_to export_user_wellbeing_assessments_path(user: @user, format: file_format, query: params[:query]),
               class: 'btn btn-primary' do %>
-    Export As <%= file_format.upcase %> <i class="fas fa-file-export"></i>
+    Export As <%= file_format.upcase %> <i class="fas <%= file_format_icon %>"></i>
   <% end %>
 <% elsif @team_member.present? %>
   <%= link_to export_team_member_wellbeing_assessments_path(team_member: @team_member, format: file_format,
                                                             query: params[:query]), class: 'btn btn-primary' do %>
-    Export As <%= file_format.upcase %> <i class="fas fa-file-export"></i>
+    Export As <%= file_format.upcase %> <i class="fas <%= file_format_icon %>"></i>
   <% end %>
 <% else %>
   <%= link_to export_wellbeing_assessments_path(format: file_format, query: params[:query]), class: 'btn btn-primary' do %>
-    Export As <%= file_format.upcase %> <i class="fas fa-file-export"></i>
+    Export As <%= file_format.upcase %> <i class="fas <%= file_format_icon %>"></i>
   <% end %>
 <% end %>

--- a/app/views/team_members/wellbeing_assessments/_export_btn.html.erb
+++ b/app/views/team_members/wellbeing_assessments/_export_btn.html.erb
@@ -1,12 +1,12 @@
 <% if @user.present? %>
   <%= link_to export_user_wellbeing_assessments_path(user: @user, format: file_format, query: params[:query]),
               class: 'btn btn-primary' do %>
-    Export As <%= file_format.capitalize %> <i class="fas fa-file-export"></i>
+    Export As <%= file_format.upcase %> <i class="fas fa-file-export"></i>
   <% end %>
 <% elsif @team_member.present? %>
   <%= link_to export_team_member_wellbeing_assessments_path(team_member: @team_member, format: file_format,
                                                             query: params[:query]), class: 'btn btn-primary' do %>
-    Export As <%= file_format.capitalize %> <i class="fas fa-file-export"></i>
+    Export As <%= file_format.upcase %> <i class="fas fa-file-export"></i>
   <% end %>
 <% else %>
   <%= link_to export_wellbeing_assessments_path(format: file_format, query: params[:query]), class: 'btn btn-primary' do %>

--- a/app/views/team_members/wellbeing_assessments/index.html.erb
+++ b/app/views/team_members/wellbeing_assessments/index.html.erb
@@ -4,10 +4,8 @@
     <div id="card-view" class="container p-0">
       <div class="row mb-3">
         <div class="col">
-          <%= link_to export_user_wellbeing_assessments_path(user: @user, format: 'csv', query: params[:query]),
-                      class: 'btn btn-primary' do %>
-            Export Wellbeing Assessments <i class="fas fa-file-export"></i>
-          <% end %>
+          <%= render(partial: 'export_btn', locals: { file_format: 'csv' }) %>
+          <%= render(partial: 'export_btn', locals: { file_format: 'json' }) %>
         </div>
       </div>
       <div class="row">
@@ -46,13 +44,10 @@
              index: @team_member.present? ? 'team_member_wellbeing_assessments' : 'wellbeing_assessments',
              stats: render('stats_non_user') do %>
     <div class="container p-0">
-      <div class="row mb-3">
-        <div class="col">
-          <%= link_to @team_member.present? ?
-            export_team_member_wellbeing_assessments_path(team_member: @team_member, format: 'csv', query: params[:query]) :
-            export_wellbeing_assessments_path(format: 'csv', query: params[:query]), class: 'btn btn-primary' do %>
-          Export Wellbeing Assessments <i class="fas fa-file-export"></i>
-          <% end %>
+      <div class="row mb-3 ">
+        <div class="col text-end">
+          <%= render(partial: 'export_btn', locals: { file_format: 'csv' }) %>
+          <%= render(partial: 'export_btn', locals: { file_format: 'json' }) %>
         </div>
       </div>
       <div class="row">

--- a/app/views/team_members/wellbeing_assessments/index.html.erb
+++ b/app/views/team_members/wellbeing_assessments/index.html.erb
@@ -4,8 +4,8 @@
     <div id="card-view" class="container p-0">
       <div class="row mb-3">
         <div class="col text-end">
-          <%= render(partial: 'export_btn', locals: { file_format: 'csv' }) %>
-          <%= render(partial: 'export_btn', locals: { file_format: 'json' }) %>
+          <%= render(partial: 'export_btn', locals: { file_format: 'csv', file_format_icon: 'fa-table' }) %>
+          <%= render(partial: 'export_btn', locals: { file_format: 'json', file_format_icon: 'fa-code' }) %>
         </div>
       </div>
       <div class="row">
@@ -46,8 +46,8 @@
     <div class="container p-0">
       <div class="row mb-3 ">
         <div class="col text-end">
-          <%= render(partial: 'export_btn', locals: { file_format: 'csv' }) %>
-          <%= render(partial: 'export_btn', locals: { file_format: 'json' }) %>
+          <%= render(partial: 'export_btn', locals: { file_format: 'csv', file_format_icon: 'fa-table' }) %>
+          <%= render(partial: 'export_btn', locals: { file_format: 'json', file_format_icon: 'fa-code' }) %>
         </div>
       </div>
       <div class="row">

--- a/app/views/team_members/wellbeing_assessments/index.html.erb
+++ b/app/views/team_members/wellbeing_assessments/index.html.erb
@@ -2,6 +2,14 @@
   <%= render 'layouts/searchable', class_list: 'team-members wellbeing-assessments', header: "#{@user.full_name}",
              subheader: "wellbeing assessments", index: 'user_wellbeing_assessments', search: render('search'), stats: render('stats')  do %>
     <div id="card-view" class="container p-0">
+      <div class="row mb-3">
+        <div class="col">
+          <%= link_to export_user_wellbeing_assessments_path(user: @user, format: 'csv', query: params[:query]),
+                      class: 'btn btn-primary' do %>
+            Export Wellbeing Assessments <i class="fas fa-file-export"></i>
+          <% end %>
+        </div>
+      </div>
       <div class="row">
         <% @resources.each do |wellbeing_assessment| %>
           <%= render 'card', wellbeing_assessment: wellbeing_assessment %>
@@ -9,6 +17,14 @@
       </div>
     </div>
     <div id="table-view" class="d-none p-0">
+      <div class="row mb-3">
+        <div class="col">
+          <%= link_to export_user_wellbeing_assessments_path(user: @user, format: 'csv', query: params[:query]),
+                      class: 'btn btn-primary' do %>
+            Export Wellbeing Assessments <i class="fas fa-file-export"></i>
+          <% end %>
+        </div>
+      </div>
       <small class="pb-2 mobile-hint">
         Table too big? Try turing your phone sideways or checking out this page on your computer
       </small>
@@ -30,6 +46,15 @@
              index: @team_member.present? ? 'team_member_wellbeing_assessments' : 'wellbeing_assessments',
              stats: render('stats_non_user') do %>
     <div class="container p-0">
+      <div class="row mb-3">
+        <div class="col">
+          <%= link_to @team_member.present? ?
+            export_team_member_wellbeing_assessments_path(team_member: @team_member, format: 'csv', query: params[:query]) :
+            export_wellbeing_assessments_path(format: 'csv', query: params[:query]), class: 'btn btn-primary' do %>
+          Export Wellbeing Assessments <i class="fas fa-file-export"></i>
+          <% end %>
+        </div>
+      </div>
       <div class="row">
         <% @resources.each do |wellbeing_assessment| %>
           <%= render 'card', wellbeing_assessment: wellbeing_assessment %>

--- a/app/views/team_members/wellbeing_assessments/index.html.erb
+++ b/app/views/team_members/wellbeing_assessments/index.html.erb
@@ -3,7 +3,7 @@
              subheader: "wellbeing assessments", index: 'user_wellbeing_assessments', search: render('search'), stats: render('stats')  do %>
     <div id="card-view" class="container p-0">
       <div class="row mb-3">
-        <div class="col">
+        <div class="col text-end">
           <%= render(partial: 'export_btn', locals: { file_format: 'csv' }) %>
           <%= render(partial: 'export_btn', locals: { file_format: 'json' }) %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,9 @@ Rails.application.routes.draw do
 
         resources :user_profile_view_logs, only: :index, on: :member
         resources :journal_entry_view_logs, only: :index, on: :member
-        resources :wellbeing_assessments, only: :index, on: :member
+        resources :wellbeing_assessments, only: :index, on: :member do
+          get 'export', on: :collection
+        end
       end
 
       resources :users, only: %i[index show] do
@@ -66,7 +68,9 @@ Rails.application.routes.draw do
         put 'unpin', action: 'unpin', on: :member, as: :unpin
         resources :notes, only: %i[create update show]
         get 'wba_history', action: 'wba_history', on: :member
-        resources :wellbeing_assessments, only: %i[new create index], on: :member
+        resources :wellbeing_assessments, only: %i[new create index], on: :member do
+          get 'export', on: :collection
+        end
         resources :appointments, only: %i[index new create edit update], on: :member
         resources :tags, only: %i[create destroy], on: :member, controller: :user_tags
       end
@@ -77,7 +81,9 @@ Rails.application.routes.draw do
         resources :notes, only: %i[create show update], controller: :crisis_notes
       end
 
-      resources :wellbeing_assessments, only: %i[show index]
+      resources :wellbeing_assessments, only: %i[show index] do
+        get 'export', on: :collection
+      end
       resources :journal_entries, only: %i[show index]
       resources :wellbeing_services
       resources :wellbeing_metrics, only: %i[index update]


### PR DESCRIPTION
I've created a new concern called 'Exportable' that can be used to covert any index of information into a CSV/JSON file so long as the model for the resource being exported implements the needed functions, currently this export is only being applied to the wellbeing assessment indexes in the team members scope.

Worth noting that I've also integrated this concern with the functionality from the Pagination concern meaning if the team members wants to manipulate the index with a search query and export the result of this they can! This also means we can update the search controls for the wellbeing assessments index to allow team members to filter based on date range, sex, tags etc. and have the results of that filtering reflected in the files exported from the system so team members can generate datasets like 'WBA of **Women** named **Joanne** in the **Last Month**' and so on. It also means that the additional controls we have for 'Viewed/Not Viewed' and 'Emoji' in the Journal Entries index will be preserve if we end up implementing the exports there too.

The addition of these additional search controls were not in the scope of this ticket however so if we want them we should create a new ticket.

<img width="1440" alt="Screenshot 2021-06-02 at 15 14 04" src="https://user-images.githubusercontent.com/6815945/120497359-3c6a5d80-c3b6-11eb-9b0b-c325915f1628.png">