### PR TITLE
Feature - IJ 193 Extra User Fields

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -230,13 +230,24 @@
   }
 
   &.edit {
-    .col-lg-6 {
-      margin-bottom: 1rem;
+    .col {
       border-radius: 0.5rem;
       padding-bottom: 1rem;
 
       @media screen and (min-width: $screen-md) {
         background: $blue-grad;
+      }
+
+      .col-lg {
+        padding: 0;
+      }
+
+      hr {
+        margin-top: 1rem;
+
+        @media screen and (min-width: $screen-lg) {
+          display: none;
+        }
       }
 
       form {
@@ -263,7 +274,7 @@
         }
 
         input[type="submit"] {
-          margin-top: 0.5rem;
+          margin-top: 1rem;
         }
       }
     }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -142,6 +142,14 @@
 
   &.show {
     #user-info {
+      .edit-user-details {
+        text-decoration: none;
+
+        .fa-edit {
+          font-size: 1.5rem;
+        }
+      }
+
       h4 {
         color: $dark-grey;
       }
@@ -206,7 +214,6 @@
       }
     }
 
-
     .wellbeing-chart.wrapper {
       .row {
         padding-left: 0 !important;
@@ -218,6 +225,46 @@
 
       canvas, .pyramid {
         margin: 1.5rem 0;
+      }
+    }
+  }
+
+  &.edit {
+    .col-lg-6 {
+      margin-bottom: 1rem;
+      border-radius: 0.5rem;
+      padding-bottom: 1rem;
+
+      @media screen and (min-width: $screen-md) {
+        background: $blue-grad;
+      }
+
+      form {
+        .col-md {
+          padding: 0;
+
+          @media screen and (min-width: $screen-md){
+            &:first-child {
+              padding-right: 0.25rem;
+            }
+
+            &:last-child {
+              padding-left: 0.25rem;
+            }
+          }
+        }
+
+        .form-floating {
+          margin-bottom: 0.5rem;
+
+          input[disabled] {
+            opacity: 0.8;
+          }
+        }
+
+        input[type="submit"] {
+          margin-top: 0.5rem;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -142,18 +142,11 @@
 
   &.show {
     #user-info {
+      padding: 0 1rem;
+
       .edit-user-details {
         text-decoration: none;
-
-        .fa-edit {
-          font-size: 1.5rem;
-        }
       }
-
-      h4 {
-        color: $dark-grey;
-      }
-      padding: 0 1rem;
 
       p {
         margin: 0;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     added_attrs = %i[
-      first_name last_name mobile_number release_date email password password_confirmation remember_me 
+      first_name last_name mobile_number release email password password_confirmation remember_me
       terms date_of_birth sex gender_identity pronouns ethnic_group religion disabilities
     ]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # app/controllers/application_controller.rb
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :deletion_date, :active_crisis_events, :crisis_event, :crisis_types, if: :user_signed_in?
+  before_action :deletion, :active_crisis_events, :crisis_event, :crisis_types, if: :user_signed_in?
 
   protected
 
@@ -14,14 +14,14 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
   end
 
-  def deletion_date
-    return unless current_user.deletion_date.present?
+  def deletion
+    return unless current_user.deletion.present?
 
-    if current_user.deletion_date <= DateTime.now
+    if current_user.deletion <= DateTime.now
       current_user.destroy!
       sign_out_and_redirect(current_user)
     else
-      @deletion_date = current_user.deletion_date.to_f * 1000
+      @deletion_date = current_user.deletion.to_f * 1000
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     added_attrs = %i[
-      first_name last_name mobile_number release email password password_confirmation remember_me
+      first_name last_name mobile_number released_at email password password_confirmation remember_me
       terms date_of_birth sex gender_identity pronouns ethnic_group religion disabilities
     ]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -66,6 +66,13 @@ module TeamMembers
       render 'edit'
     end
 
+    # PUT /users/:user_id
+    def update
+      @user.update(user_params)
+
+      redirect_to user_path(@user), flash: { success: "#{@user.full_name} was successfully updated." }
+    end
+
     protected
 
     def resources
@@ -150,6 +157,12 @@ module TeamMembers
       @total_users = User.all.count
       @active_last_week = @resources.active_last_week.size
       @active_last_month = @resources.active_last_month.size
+    end
+
+    def user_params
+      params.require(:user).permit(:release, :nomis_id, :pnc_no, :delius_no, :enrolment, :intervention,
+                                   :release_establishment, :probation_area, :local_authority, :pilot_completed,
+                                   :pilot_withdrawn, :withdrawn, :withdrawn_reason, :index_offence)
     end
   end
 end

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -61,6 +61,11 @@ module TeamMembers
       end
     end
 
+    # GET /users/:user_id/edit
+    def edit
+      render 'edit'
+    end
+
     protected
 
     def resources

--- a/app/controllers/team_members/users_controller.rb
+++ b/app/controllers/team_members/users_controller.rb
@@ -160,9 +160,9 @@ module TeamMembers
     end
 
     def user_params
-      params.require(:user).permit(:release, :nomis_id, :pnc_no, :delius_no, :enrolment, :intervention,
-                                   :release_establishment, :probation_area, :local_authority, :pilot_completed,
-                                   :pilot_withdrawn, :withdrawn, :withdrawn_reason, :index_offence)
+      params.require(:user).permit(:released_at, :nomis_id, :pnc_no, :delius_no, :enrolled_at, :intervened_at,
+                                   :release_establishment, :probation_area, :local_authority, :pilot_completed_at,
+                                   :pilot_withdrawn_at, :withdrawn, :withdrawn_reason, :index_offence)
     end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,7 +6,7 @@ module Users
 
     # DELETE /users
     def destroy
-      current_user.update!(deletion_date: Time.now + 30.days)
+      current_user.update!(deletion: Time.now + 30.days)
 
       redirect_back(fallback_location: authenticated_user_root_path)
     end

--- a/app/controllers/users/users_application_controller.rb
+++ b/app/controllers/users/users_application_controller.rb
@@ -13,7 +13,7 @@ module Users
 
     # PUT /cancel_deletion
     def cancel_deletion
-      current_user.update!(deletion_date: nil)
+      current_user.update!(deletion: nil)
 
       redirect_back(fallback_location: authenticated_user_root_path,
                     flash: { success: 'Your account will no longer be deleted.' })

--- a/app/javascript/packs/wellbeing_history_chart.js
+++ b/app/javascript/packs/wellbeing_history_chart.js
@@ -73,7 +73,7 @@ const carousel = document.querySelector('#wellbeing-history-chart-carousel'),
         parent.querySelectorAll(css_selector)[event.target.value].classList.add('active')
     }
 
-fetch(`${location}/wba_history`, {
+fetch(`${location.origin}${location.pathname}/wba_history`, {
     headers: {
         'Content-Type': 'application/json'
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < DeviseRecord
   has_many :user_profile_view_logs, foreign_key: :user_id, dependent: :delete_all
   has_many :user_tags, foreign_key: :user_id, dependent: :delete_all
 
-  scope :can_be_deleted, -> { where('deletion_date is not null and deletion_date <= ?', Time.now) }
+  scope :can_be_deleted, -> { where('deletion is not null and deletion <= ?', Time.now) }
   scope :active_last_week, -> { where('current_sign_in_at >= ?', 1.week.ago) }
   scope :active_last_month, -> { where('current_sign_in_at >= ?', 1.month.ago) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,8 +21,8 @@ class User < DeviseRecord
   scope :active_last_week, -> { where('current_sign_in_at >= ?', 1.week.ago) }
   scope :active_last_month, -> { where('current_sign_in_at >= ?', 1.month.ago) }
 
-  def release
-    release_date.present? ? release_date.strftime('%d/%m/%Y') : ''
+  def release_date
+    release.present? ? release.strftime('%d/%m/%Y') : ''
   end
 
   def dob

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < DeviseRecord
   scope :active_last_month, -> { where('current_sign_in_at >= ?', 1.month.ago) }
 
   def release_date
-    release.present? ? release.strftime('%d/%m/%Y') : ''
+    released_at.present? ? released_at.strftime('%d/%m/%Y') : ''
   end
 
   def dob
@@ -72,7 +72,7 @@ class User < DeviseRecord
       id,
       full_name,
       dob,
-      release,
+      released_at,
       sex,
       gender_identity,
       ethnic_group,
@@ -86,7 +86,7 @@ class User < DeviseRecord
       'ID': id,
       'Name': full_name,
       'Date Of Birth': dob,
-      'Release Date': release,
+      'Release Date': released_at,
       'Sex': sex,
       'Gender Identity': gender_identity,
       'Ethnic Group': ethnic_group,

--- a/app/views/team_members/users/_card.html.erb
+++ b/app/views/team_members/users/_card.html.erb
@@ -46,7 +46,7 @@
                   <i class="fas fa-phone-alt"></i> <%= "0#{user.mobile_number}" %>
                 <% end %>
               </div>
-              <% if user.release.present? %>
+              <% if user.released_at.present? %>
                 <div class="row">
                   <span><i class="fas fa-calendar"></i> Release: <%= user.release_date %></span>
                 </div>

--- a/app/views/team_members/users/_card.html.erb
+++ b/app/views/team_members/users/_card.html.erb
@@ -46,9 +46,9 @@
                   <i class="fas fa-phone-alt"></i> <%= "0#{user.mobile_number}" %>
                 <% end %>
               </div>
-              <% if user.release_date.present? %>
+              <% if user.release.present? %>
                 <div class="row">
-                  <span><i class="fas fa-calendar"></i> Release: <%= user.release %></span>
+                  <span><i class="fas fa-calendar"></i> Release: <%= user.release_date %></span>
                 </div>
               <% end %>
               <% unread_journal_entries = current_team_member.unread_journal_entries(user) %>

--- a/app/views/team_members/users/edit.html.erb
+++ b/app/views/team_members/users/edit.html.erb
@@ -114,8 +114,8 @@
                 <div class="row">
                   <div class="col-md">
                     <div class="form-floating">
-                      <%= f.date_field :release, class: 'form-control', placeholder: 'Release' %>
-                      <%= f.label :release %>
+                      <%= f.date_field :released_at, class: 'form-control', placeholder: 'Release' %>
+                      <%= f.label :released_at %>
                     </div>
                   </div>
                   <div class="col-md">
@@ -150,14 +150,14 @@
                 <div class="row">
                   <div class="col-md">
                     <div class="form-floating">
-                      <%= f.date_field :enrolment, class: 'form-control' %>
-                      <%= f.label :enrolment %>
+                      <%= f.date_field :enrolled_at, class: 'form-control' %>
+                      <%= f.label :enrolled_at %>
                     </div>
                   </div>
                   <div class="col-md">
                     <div class="form-floating">
-                      <%= f.date_field :intervention, class: 'form-control' %>
-                      <%= f.label :intervention do %>
+                      <%= f.date_field :intervened_at, class: 'form-control' %>
+                      <%= f.label :intervened_at do %>
                         Began Receiving Intervention
                       <% end %>
                     </div>
@@ -194,16 +194,16 @@
                 <div class="row">
                   <div class="col-md">
                     <div class="form-floating">
-                      <%= f.date_field :pilot_completed, class: 'form-control', placeholder: 'Completed Pilot' %>
-                      <%= f.label :pilot_completed do %>
+                      <%= f.date_field :pilot_completed_at, class: 'form-control', placeholder: 'Completed Pilot' %>
+                      <%= f.label :pilot_completed_at do %>
                         Completed Pilot
                       <% end %>
                     </div>
                   </div>
                   <div class="col-md">
                     <div class="form-floating">
-                      <%= f.date_field :pilot_withdrawn, class: 'form-control', placeholder: 'Withdrawn' %>
-                      <%= f.label :pilot_withdrawn do %>
+                      <%= f.date_field :pilot_withdrawn_at, class: 'form-control', placeholder: 'Withdrawn' %>
+                      <%= f.label :pilot_withdrawn_at do %>
                         Withdrawn
                       <% end %>
                     </div>

--- a/app/views/team_members/users/edit.html.erb
+++ b/app/views/team_members/users/edit.html.erb
@@ -1,7 +1,7 @@
 <main class="container team-members users edit">
   <section class="row">
     <div class="col">
-      <%= form_with model: @user, url: '#' do |f| %>
+      <%= form_with model: @user, url: user_path(@user), method: :put do |f| %>
         <div class="form-group">
           <%= render "team_members/shared/error_messages", resource: @user %>
 

--- a/app/views/team_members/users/edit.html.erb
+++ b/app/views/team_members/users/edit.html.erb
@@ -1,0 +1,239 @@
+<main class="container team-members users edit">
+  <section class="row">
+    <div class="col">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-6">
+            <%= form_with model: @user, url: '#' do |f| %>
+              <div class="form-group">
+                <%= render "team_members/shared/error_messages", resource: @user %>
+
+                <p class="text-danger">
+                  <% if flash[:alert] %>
+                    <%= flash[:alert] %>
+                  <% end %>
+                </p>
+              </div>
+
+              <div class="container">
+                <h3>User Defined Details</h3>
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :first_name, class: 'form-control', disabled: true %>
+                      <%= f.label :first_name %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :last_name, class: 'form-control', disabled: true %>
+                      <%= f.label :last_name %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :pronouns, class: 'form-control', disabled: true %>
+                      <%= f.label :pronouns %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.date_field :date_of_birth, class: 'form-control', disabled: true %>
+                      <%= f.label :date_of_birth %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :email, class: 'form-control', disabled: true %>
+                      <%= f.label :email %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :mobile_number, class: 'form-control', disabled: true %>
+                      <%= f.label :mobile_number %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :sex, class: 'form-control', disabled: true %>
+                      <%= f.label :sex %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :gender_identity, class: 'form-control', disabled: true %>
+                      <%= f.label :gender_identity do %>
+                        Gender
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :religion, class: 'form-control', disabled: true %>
+                      <%= f.label :religion %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :ethnic_group, class: 'form-control', disabled: true %>
+                      <%= f.label :ethnic_group do %>
+                        Ethnicity
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col p-0">
+                    <div class="form-floating mb-0">
+                      <%= f.text_field :disabilities, class: 'form-control', disabled: true %>
+                      <%= f.label :disabilities %>
+                    </div>
+                  </div>
+                </div>
+
+                <hr />
+
+                <h3>Team Member Defined Details</h3>
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.date_field :release, class: 'form-control', disabled: true %>
+                      <%= f.label :release %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :nomis_id, class: 'form-control', placeholder: 'NOMIS ID' %>
+                      <%= f.label :nomis_id do %>
+                        NOMIS ID
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :pnc_no, class: 'form-control', placeholder: 'PNC No.' %>
+                      <%= f.label :pnc_no do %>
+                        PNC No.
+                      <% end %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :delius_no, class: 'form-control', placeholder: 'DELIUS No.' %>
+                      <%= f.label :delius_no do %>
+                        DELIUS No.
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.date_field :enrolment, class: 'form-control' %>
+                      <%= f.label :enrolment %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.date_field :intervention, class: 'form-control' %>
+                      <%= f.label :intervention do %>
+                        Began Receiving Intervention
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col p-0">
+                    <div class="form-floating">
+                      <%= f.text_field :release_establishment, class: 'form-control',
+                                       placeholder: 'Establishment Released From' %>
+                      <%= f.label :release_establishment do %>
+                        Establishment Released From
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :probation_area, class: 'form-control', placeholder: 'Probation Area' %>
+                      <%= f.label :probation_area %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.text_field :local_authority, class: 'form-control', placeholder: 'Local Authority' %>
+                      <%= f.label :local_authority %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.date_field :pilot_completed, class: 'form-control', placeholder: 'Completed Pilot' %>
+                      <%= f.label :pilot_completed do %>
+                        Completed Pilot
+                      <% end %>
+                    </div>
+                  </div>
+                  <div class="col-md">
+                    <div class="form-floating">
+                      <%= f.date_field :pilot_withdrawn, class: 'form-control', placeholder: 'Withdrawn' %>
+                      <%= f.label :pilot_withdrawn do %>
+                        Withdrawn
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col p-0">
+                    <div class="form-floating">
+                      <%= f.text_field :withdrawn_reason, class: 'form-control', placeholder: 'Reason For Withdrawal' %>
+                      <%= f.label :withdrawn_reason do %>
+                        Reason For Withdrawal
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col p-0">
+                    <div class="form-floating">
+                      <%= f.text_field :index_offence, class: 'form-control', placeholder: 'Index Offence' %>
+                      <%= f.label :index_offence do %>
+                        Index Offence
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <%= f.submit 'Update', class: 'btn btn-primary' %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>

--- a/app/views/team_members/users/edit.html.erb
+++ b/app/views/team_members/users/edit.html.erb
@@ -1,22 +1,22 @@
 <main class="container team-members users edit">
   <section class="row">
     <div class="col">
-      <div class="container">
-        <div class="row justify-content-center">
-          <div class="col-lg-6">
-            <%= form_with model: @user, url: '#' do |f| %>
-              <div class="form-group">
-                <%= render "team_members/shared/error_messages", resource: @user %>
+      <%= form_with model: @user, url: '#' do |f| %>
+        <div class="form-group">
+          <%= render "team_members/shared/error_messages", resource: @user %>
 
-                <p class="text-danger">
-                  <% if flash[:alert] %>
-                    <%= flash[:alert] %>
-                  <% end %>
-                </p>
-              </div>
+          <p class="text-danger">
+            <% if flash[:alert] %>
+              <%= flash[:alert] %>
+            <% end %>
+          </p>
+        </div>
 
+        <div class="container">
+          <h3>User Details</h3>
+          <div class="row">
+            <div class="col-lg">
               <div class="container">
-                <h3>User Defined Details</h3>
                 <div class="row">
                   <div class="col-md">
                     <div class="form-floating">
@@ -104,14 +104,17 @@
                     </div>
                   </div>
                 </div>
+              </div>
+            </div>
 
-                <hr />
+            <hr />
 
-                <h3>Team Member Defined Details</h3>
+            <div class="col-lg">
+              <div class="container">
                 <div class="row">
                   <div class="col-md">
                     <div class="form-floating">
-                      <%= f.date_field :release, class: 'form-control', disabled: true %>
+                      <%= f.date_field :release, class: 'form-control', placeholder: 'Release' %>
                       <%= f.label :release %>
                     </div>
                   </div>
@@ -229,11 +232,11 @@
                   </div>
                 </div>
               </div>
-              <%= f.submit 'Update', class: 'btn btn-primary' %>
-            <% end %>
+            </div>
           </div>
         </div>
-      </div>
+        <%= f.submit 'Update', class: 'btn btn-primary' %>
+      <% end %>
     </div>
   </section>
 </main>

--- a/app/views/team_members/users/show.html.erb
+++ b/app/views/team_members/users/show.html.erb
@@ -1,8 +1,9 @@
 <main class="container team-members users show">
   <div id="user-info" class="row mt-3 mb-3">
     <div class="col-12 col-md-6 col-lg-4 mx-auto">
+      <h1 class="text-center mb-0"><%= @user.full_name %></h1>
       <%= link_to edit_user_path(@user), class: 'edit-user-details' do %>
-        <h1 class="text-center mb-0"><%= @user.full_name %> <i class="fas fa-edit"></i></h1>
+        <h4 class="text-center">Edit Details <i class="fas fa-edit"></i></h4>
       <% end %>
       <% if @user.pronouns.present? %>
         <h4 class="text-center"><%= @user.pronouns %></h4>

--- a/app/views/team_members/users/show.html.erb
+++ b/app/views/team_members/users/show.html.erb
@@ -19,7 +19,7 @@
         <% end %>
       </p>
       <p>
-        <i class="fas fa-calendar"></i> Release: <%= @user.release %>
+        <i class="fas fa-calendar"></i> Release: <%= @user.release_date %>
       </p>
       <p>
         <% unless @unread_journal_entries.zero? %>

--- a/app/views/team_members/users/show.html.erb
+++ b/app/views/team_members/users/show.html.erb
@@ -1,7 +1,9 @@
 <main class="container team-members users show">
   <div id="user-info" class="row mt-3 mb-3">
     <div class="col-12 col-md-6 col-lg-4 mx-auto">
-      <h1 class="text-center <%= @user.pronouns.present? ? "mb-0" : "mb-0" %>"><%= @user.full_name %></h1>
+      <%= link_to edit_user_path(@user), class: 'edit-user-details' do %>
+        <h1 class="text-center mb-0"><%= @user.full_name %> <i class="fas fa-edit"></i></h1>
+      <% end %>
       <% if @user.pronouns.present? %>
         <h4 class="text-center"><%= @user.pronouns %></h4>
       <% end %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -33,8 +33,8 @@
           <div class="row">
             <div class="col-md">
               <div class="form-floating">
-                <%= form.date_field :release_date, class: 'form-control', autocomplete: 'release-date', placeholder: 'Release Date' %>
-                <%= form.label :release_date %>
+                <%= form.date_field :release, class: 'form-control', autocomplete: 'release-date', placeholder: 'Release Date' %>
+                <%= form.label :release %>
               </div>
             </div>
             <div class="col-md">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -33,8 +33,8 @@
           <div class="row">
             <div class="col-md">
               <div class="form-floating">
-                <%= form.date_field :release, class: 'form-control', autocomplete: 'release-date', placeholder: 'Release Date' %>
-                <%= form.label :release %>
+                <%= form.date_field :released_at, class: 'form-control', autocomplete: 'release-date', placeholder: 'Release Date' %>
+                <%= form.label :released_at %>
               </div>
             </div>
             <div class="col-md">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -35,8 +35,8 @@
         </div>
 
         <div class="form-floating">
-          <%= f.date_field :release_date, class: 'form-control', autocomplete: "release-date", placeholder: "Release Date" %>
-          <%= f.label :release_date %>
+          <%= f.date_field :release, class: 'form-control', autocomplete: "release-date", placeholder: "Release Date" %>
+          <%= f.label :release %>
         </div>
 
         <div class="form-floating">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -35,8 +35,8 @@
         </div>
 
         <div class="form-floating">
-          <%= f.date_field :release, class: 'form-control', autocomplete: "release-date", placeholder: "Release Date" %>
-          <%= f.label :release %>
+          <%= f.date_field :released_at, class: 'form-control', autocomplete: "release-date", placeholder: "Release Date" %>
+          <%= f.label :released_at %>
         </div>
 
         <div class="form-floating">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
         end
         resources :appointments, only: %i[index new create edit update], on: :member
         resources :tags, only: %i[create destroy], on: :member, controller: :user_tags
+        get 'edit', action: 'edit', on: :member, as: :edit
       end
 
       resources :crisis_events, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :users, only: %i[index show] do
+      resources :users, only: %i[index show update] do
         put 'pin', action: 'pin', on: :member, as: :pin
         put 'increment', action: 'increment', on: :member, as: :increment
         put 'decrement', action: 'decrement', on: :member, as: :decrement

--- a/db/migrate/20210225200409_devise_create_users.rb
+++ b/db/migrate/20210225200409_devise_create_users.rb
@@ -1,3 +1,4 @@
+# db/migrate/20210225200409_devise_create_users.rb
 class DeviseCreateUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :users do |t|

--- a/db/migrate/20210528104756_add_user_fields.rb
+++ b/db/migrate/20210528104756_add_user_fields.rb
@@ -16,8 +16,7 @@ class AddUserFields < ActiveRecord::Migration[6.1]
       t.string :probation_area
       t.string :local_authority
       t.date :pilot_completed
-      t.boolean :pilot_withdrawn
-      t.date :withdrawn
+      t.date :pilot_withdrawn
       t.string :withdrawn_reason
       t.string :index_offence
     end

--- a/db/migrate/20210528104756_add_user_fields.rb
+++ b/db/migrate/20210528104756_add_user_fields.rb
@@ -2,21 +2,21 @@
 class AddUserFields < ActiveRecord::Migration[6.1]
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def change
-    rename_column :users, :release_date, :release
-    rename_column :users, :deletion_date, :deletion
-    change_column :users, :release, :date
+    rename_column :users, :release_date, :released_at
+    rename_column :users, :deletion_date, :deleted_at
+    change_column :users, :released_at, :date
 
     change_table :users do |t|
       t.string :nomis_id
       t.string :pnc_no
       t.string :delius_no
-      t.date :enrolment
-      t.date :intervention
+      t.date :enrolled_at
+      t.date :intervened_at
       t.string :release_establishment
       t.string :probation_area
       t.string :local_authority
-      t.date :pilot_completed
-      t.date :pilot_withdrawn
+      t.date :pilot_completed_at
+      t.date :pilot_withdrawn_at
       t.string :withdrawn_reason
       t.string :index_offence
     end

--- a/db/migrate/20210528104756_add_user_fields.rb
+++ b/db/migrate/20210528104756_add_user_fields.rb
@@ -1,0 +1,26 @@
+# db/migrate/20210528104756_add_user_fields.rb
+class AddUserFields < ActiveRecord::Migration[6.1]
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def change
+    rename_column :users, :release_date, :release
+    rename_column :users, :deletion_date, :deletion
+    change_column :users, :release, :date
+
+    change_table :users do |t|
+      t.string :nomis_id
+      t.string :pnc_no
+      t.string :delius_no
+      t.date :enrolment
+      t.date :intervention
+      t.string :release_establishment
+      t.string :probation_area
+      t.string :local_authority
+      t.date :pilot_completed
+      t.boolean :pilot_withdrawn
+      t.date :withdrawn
+      t.string :withdrawn_reason
+      t.string :index_offence
+    end
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -253,9 +253,9 @@ ActiveRecord::Schema.define(version: 2021_05_28_104756) do
     t.string "first_name", default: "", null: false
     t.string "last_name", default: "", null: false
     t.bigint "mobile_number"
-    t.date "release"
+    t.date "released_at"
     t.boolean "terms", default: false
-    t.datetime "deletion"
+    t.datetime "deleted_at"
     t.datetime "date_of_birth"
     t.text "disabilities"
     t.string "ethnic_group"
@@ -268,13 +268,13 @@ ActiveRecord::Schema.define(version: 2021_05_28_104756) do
     t.string "nomis_id"
     t.string "pnc_no"
     t.string "delius_no"
-    t.date "enrolment"
-    t.date "intervention"
+    t.date "enrolled_at"
+    t.date "intervened_at"
     t.string "release_establishment"
     t.string "probation_area"
     t.string "local_authority"
-    t.date "pilot_completed"
-    t.date "pilot_withdrawn"
+    t.date "pilot_completed_at"
+    t.date "pilot_withdrawn_at"
     t.string "withdrawn_reason"
     t.string "index_offence"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_28_104755) do
+ActiveRecord::Schema.define(version: 2021_05_28_104756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -253,9 +253,9 @@ ActiveRecord::Schema.define(version: 2021_05_28_104755) do
     t.string "first_name", default: "", null: false
     t.string "last_name", default: "", null: false
     t.bigint "mobile_number"
-    t.datetime "release_date"
+    t.date "release"
     t.boolean "terms", default: false
-    t.datetime "deletion_date"
+    t.datetime "deletion"
     t.datetime "date_of_birth"
     t.text "disabilities"
     t.string "ethnic_group"
@@ -265,6 +265,19 @@ ActiveRecord::Schema.define(version: 2021_05_28_104755) do
     t.string "pronouns"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "nomis_id"
+    t.string "pnc_no"
+    t.string "delius_no"
+    t.date "enrolment"
+    t.date "intervention"
+    t.string "release_establishment"
+    t.string "probation_area"
+    t.string "local_authority"
+    t.date "pilot_completed"
+    t.boolean "pilot_withdrawn"
+    t.date "withdrawn"
+    t.string "withdrawn_reason"
+    t.string "index_offence"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -274,8 +274,7 @@ ActiveRecord::Schema.define(version: 2021_05_28_104756) do
     t.string "probation_area"
     t.string "local_authority"
     t.date "pilot_completed"
-    t.boolean "pilot_withdrawn"
-    t.date "withdrawn"
+    t.date "pilot_withdrawn"
     t.string "withdrawn_reason"
     t.string "index_offence"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,7 +38,7 @@ unless User.find_by_email('john.smith@me.com').present?
     last_name: 'Smith',
     email: 'john.smith@me.com',
     mobile_number: Faker::Number.leading_zero_number(digits: 11),
-    release: rand(1..2).even? ? Faker::Date.between(from: Date.today - 20.days, to: Date.today) : '',
+    released_at: rand(1..2).even? ? Faker::Date.between(from: Date.today - 20.days, to: Date.today) : '',
     terms: true,
     password: 'password'
   )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,7 +38,7 @@ unless User.find_by_email('john.smith@me.com').present?
     last_name: 'Smith',
     email: 'john.smith@me.com',
     mobile_number: Faker::Number.leading_zero_number(digits: 11),
-    release_date: rand(1..2).even? ? Faker::Date.between(from: DateTime.now - 20.days, to: DateTime.now) : '',
+    release: rand(1..2).even? ? Faker::Date.between(from: Date.today - 20.days, to: Date.today) : '',
     terms: true,
     password: 'password'
   )

--- a/db/seeds/07_users.rb
+++ b/db/seeds/07_users.rb
@@ -10,7 +10,7 @@ if User.count.zero?
       last_name: Faker::Name.last_name,
       email: "IJ-test-user-#{user_counter}@purpleriver.dev",
       mobile_number: Faker::Number.leading_zero_number(digits: 11),
-      release_date: rand(1..2).even? ? Faker::Date.between(from: DateTime.now - 20.days, to: DateTime.now) : '',
+      release: rand(1..2).even? ? Faker::Date.between(from: Date.today - 20.days, to: Date.today) : '',
       terms: true,
       password: 'test1234',
       current_sign_in_at: rand(1..100).days.ago

--- a/db/seeds/07_users.rb
+++ b/db/seeds/07_users.rb
@@ -10,7 +10,7 @@ if User.count.zero?
       last_name: Faker::Name.last_name,
       email: "IJ-test-user-#{user_counter}@purpleriver.dev",
       mobile_number: Faker::Number.leading_zero_number(digits: 11),
-      release: rand(1..2).even? ? Faker::Date.between(from: Date.today - 20.days, to: Date.today) : '',
+      released_at: rand(1..2).even? ? Faker::Date.between(from: Date.today - 20.days, to: Date.today) : '',
       terms: true,
       password: 'test1234',
       current_sign_in_at: rand(1..100).days.ago


### PR DESCRIPTION
Added the extra user fields according to the IJ-193 ticket bar the 'Sentence Length' field as we're still waiting on an update on that. I've removed the _date suffix from all of the date fields as it's redundant and have also set all date fields to date rather than datetime as this just stores redundant data if we don't care about the time.

To access the editable details section of a user a team member can click on the users heading:

<img width="1440" alt="Screenshot 2021-08-03 at 10 54 02" src="https://user-images.githubusercontent.com/6815945/127997046-807c8d53-dcd8-41bb-b14f-94f910032d0f.png">

They are then presented with a 2 column form with the LHS containing all of the users personal details which are only editable to the user and the RHS containing the additional data that team members can set:

<img width="1440" alt="Screenshot 2021-08-03 at 10 53 46" src="https://user-images.githubusercontent.com/6815945/127997076-ddd9e5fe-8472-4602-b0b2-bcc37e1e7479.png">

