### PR TITLE
Bugfix - IJ-200 - Crisis Event Mailer Fix

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -16,7 +16,7 @@
               <table class="inner">
                 <tr>
                   <td class="banner">
-                    <a href="<%= authenticated_user_root_path %>">
+                    <a href="<%= authenticated_user_root_url %>">
                       <%= email_image_tag('banner.png') %>
                     </a>
                   </td>


### PR DESCRIPTION
Fixed the mailer to use root_url rather than root_path so now emails are successfully being generated upon crisis event creation.