### PR TITLE
Feature - IJ-195 - Reminder Emails

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -25,4 +25,8 @@ class AdminMailer < ApplicationMailer
     mail(to: @admin.email, subject: " #{@user.full_name}'s crisis has been updated.")
   end
 
+  def reminder_email(user)
+    @user = user
+    mail(to: @user.email, subject: 'Wellbeing Assessment Reminder!')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,11 @@ class User < DeviseRecord
   scope :active_last_week, -> { where('current_sign_in_at >= ?', 1.week.ago) }
   scope :active_last_month, -> { where('current_sign_in_at >= ?', 1.month.ago) }
   scope :deleted, -> { where(deleted: true) }
+  scope :last_assessed_today, lambda {
+    where(':start <= last_assessed_at and last_assessed_at <= :end',
+          { start: Time.zone.now.beginning_of_day, end: Time.zone.now.end_of_day })
+  }
+  scope :not_assessed_today, -> { where.not(id: last_assessed_today) }
 
   validates_presence_of :terms
   validates :email, uniqueness: { case_sensitive: false }

--- a/app/models/wellbeing_assessment.rb
+++ b/app/models/wellbeing_assessment.rb
@@ -3,6 +3,8 @@ class WellbeingAssessment < ApplicationRecord
   belongs_to :user
   belongs_to :team_member, optional: true
 
+  after_create :set_last_assessed_at
+
   has_many :wba_scores, foreign_key: :wellbeing_assessment_id, dependent: :delete_all
 
   def today?
@@ -40,4 +42,10 @@ class WellbeingAssessment < ApplicationRecord
              })
   end
   # rubocop:enable Metrics/AbcSize
+
+  private
+
+  def set_last_assessed_at
+    user.update!(last_assessed_at: DateTime.now)
+  end
 end

--- a/app/views/admin_mailer/reminder_email.html.erb
+++ b/app/views/admin_mailer/reminder_email.html.erb
@@ -1,0 +1,4 @@
+<p>Hi <%= @user.first_name %>, this is a reminder that you haven't filled out a wellbeing assessment today.</p>
+<p>Please click the button below to login and complete a wellbeing assessment via the My Needs dashboard button.</p>
+
+<div class="btn-container"><%= link_to 'Login', users_url %></div>

--- a/db/migrate/20210528104765_add_user_last_assessed_at.rb
+++ b/db/migrate/20210528104765_add_user_last_assessed_at.rb
@@ -1,0 +1,8 @@
+# db/migrate/20210528104765_add_user_last_assessed_at.rb
+class AddUserLastAssessedAt < ActiveRecord::Migration[6.1]
+  def change
+    change_table :users do |t|
+      t.datetime :last_assessed_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_28_104764) do
+ActiveRecord::Schema.define(version: 2021_05_28_104765) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -354,6 +354,7 @@ ActiveRecord::Schema.define(version: 2021_05_28_104764) do
     t.string "withdrawn_reason"
     t.string "index_offence"
     t.boolean "deleted", default: false, null: false
+    t.datetime "last_assessed_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -3,4 +3,9 @@ namespace :users do
   task delete: :environment do
     User.can_be_deleted.destroy_all
   end
+
+  desc 'This task is used to send users email reminders'
+  task send_reminder_email: :environment do
+    User.not_assessed_today.each { |user| AdminMailer.reminder_email(user).deliver_now }
+  end
 end


### PR DESCRIPTION
I've updated the user record to record when a user was last assessed and added a scope to get all the users who were not assessed on the current day. I've then created a new admin mailer template to remind the users who have not been assessed to login and complete a wellbeing assessment along with a rake task that can be used in conjunction with a cronjob (or Heroku scheduler) to trigger sending out those reminder emails at some specified time (13:00 according to the ticket).

To run this locally create a user account connected to the email address you want to receive the reminder at, don't create a wellbeing assessment today unless you want to test that a reminder *won't* be sent, make sure the `SENDGRID_API_KEY` environment variable is set and run `bundle exec rake users:send_reminder_email`.

You will then receive the below:

![Screenshot 2021-08-20 at 14 09 47](https://user-images.githubusercontent.com/6815945/130239104-1e8c3254-476e-4401-9ae9-c3aac24ae5dd.png)
