### PR TITLE
Update Form Input Styles

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -54,6 +54,25 @@
         color: $white;
       }
 
+      .form-control {
+        &:focus {
+          box-shadow: 0 0 0 0.2rem $brand-primary-dark;
+        }
+
+        &.invalid {
+          box-shadow: 0 0 0 0.2rem $danger;
+        }
+      }
+
+      .error-message {
+        position: absolute;
+        top: -0.5rem;
+        right: 0;
+        padding: 1rem 0.75rem;
+        color: $danger;
+        font-size: 0.85rem;
+      }
+
       a {
         text-decoration: none;
         font-weight: 600;
@@ -106,6 +125,10 @@
       }
 
       .form-check {
+        padding: 0.5rem;
+        position: relative;
+        border-radius: 0.25rem;
+
         .form-check-input {
           float: none;
 
@@ -116,6 +139,10 @@
 
         .form-check-label {
           color: $white;
+        }
+
+        .error-message {
+          // display: none;
         }
       }
 

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -140,10 +140,6 @@
         .form-check-label {
           color: $white;
         }
-
-        .error-message {
-          // display: none;
-        }
       }
 
       .other-actions {

--- a/app/views/team_members/confirmations/new.html.erb
+++ b/app/views/team_members/confirmations/new.html.erb
@@ -7,7 +7,6 @@
             <h2>Resend confirmation instructions</h2>
 
             <div class="form-group">
-              <%= render "team_members/shared/error_messages", resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/app/views/team_members/passwords/edit.html.erb
+++ b/app/views/team_members/passwords/edit.html.erb
@@ -7,7 +7,6 @@
             <h2>Change your password</h2>
 
             <div class="form-group">
-              <%= render 'team_members/shared/error_messages', resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/app/views/team_members/passwords/new.html.erb
+++ b/app/views/team_members/passwords/new.html.erb
@@ -7,7 +7,6 @@
             <h2>Forgot your password?</h2>
 
             <div class="form-group">
-              <%= render "team_members/shared/error_messages", resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/app/views/team_members/registrations/edit.html.erb
+++ b/app/views/team_members/registrations/edit.html.erb
@@ -6,7 +6,6 @@
         <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
         <div class="form-group">
-          <%= render "team_members/shared/error_messages", resource: resource %>
           <p class="text-danger">
             <% if flash[:alert] %>
               <%= flash[:alert] %>

--- a/app/views/team_members/registrations/new.html.erb
+++ b/app/views/team_members/registrations/new.html.erb
@@ -5,7 +5,6 @@
         <h2><i class="fas fa-users"></i> Sign up</h2>
 
         <div class="form-group">
-          <%= render "team_members/shared/error_messages", resource: resource %>
           <p class="text-danger">
             <% if flash[:alert] %>
               <%= flash[:alert] %>

--- a/app/views/team_members/sessions/new.html.erb
+++ b/app/views/team_members/sessions/new.html.erb
@@ -10,7 +10,6 @@
             <h2><i class="fas fa-users"></i> Log in</h2>
 
             <div class="form-group">
-              <%= render "team_members/shared/error_messages", resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/app/views/team_members/unlocks/new.html.erb
+++ b/app/views/team_members/unlocks/new.html.erb
@@ -7,7 +7,6 @@
             <h2>Resend unlock instructions</h2>
 
             <div class="form-group">
-              <%= render "team_members/shared/error_messages", resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/app/views/team_members/users/edit.html.erb
+++ b/app/views/team_members/users/edit.html.erb
@@ -3,7 +3,6 @@
     <div class="col">
       <%= form_with model: @user, url: user_path(@user), method: :put do |f| %>
         <div class="form-group">
-          <%= render "team_members/shared/error_messages", resource: @user %>
 
           <p class="text-danger">
             <% if flash[:alert] %>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -7,7 +7,6 @@
             <h2>Resend confirmation instructions</h2>
 
             <div class="form-group">
-              <%= render "users/shared/error_messages", resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -7,7 +7,6 @@
             <h2>Change your password</h2>
 
             <div class="form-group">
-              <%= render 'users/shared/error_messages', resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -7,7 +7,6 @@
             <h2>Forgot your password?</h2>
 
             <div class="form-group">
-              <%= render "users/shared/error_messages", resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -6,7 +6,6 @@
         <h2>Edit <%= resource_name.to_s.humanize %></h2>
         
         <div class="form-group">
-          <%= render 'users/shared/error_messages', resource: resource %>
           <p class="text-danger">
             <% if flash[:alert] %>
               <%= flash[:alert] %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -5,7 +5,6 @@
         <h2><i class="fas fa-user"></i> Sign up</h2>
 
         <div class="form-group">
-          <%= render "users/shared/error_messages", resource: resource %>
           <p class="text-danger">
             <% if flash[:alert] %>
               <%= flash[:alert] %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -33,7 +33,6 @@
             <h2><i class="fas fa-user"></i> Log in</h2>
 
             <div class="form-group">
-              <%= render "users/shared/error_messages", resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -7,7 +7,6 @@
             <h2>Resend unlock instructions</h2>
 
             <div class="form-group">
-              <%= render "users/shared/error_messages", resource: resource %>
               <p class="text-danger">
                 <% if flash[:alert] %>
                   <%= flash[:alert] %>

--- a/config/initializers/custom_form_errors.rb
+++ b/config/initializers/custom_form_errors.rb
@@ -1,0 +1,31 @@
+ActionView::Base.field_error_proc = proc do |html_tag, instance|
+  fragment = Nokogiri::HTML.fragment(html_tag)
+  field = fragment.at('input,select,textarea')
+  error_messages = instance.object.errors.messages
+
+  html = nil
+  if field
+    field['class'] = "#{field['class']} invalid"
+
+    value = field.attributes['name']
+                 .value
+                 .match(/\[(.*?)\]/)[0]
+                 .delete('[]')
+                 .gsub('_', ' ')
+
+    error_message = error_messages[value.to_sym][0]
+    error_message = 'is invalid' unless error_message.present?
+
+    html = <<HTML
+#{fragment.to_s} 
+<span class=\"error-message\">
+#{value.capitalize} #{error_message}
+</span>
+HTML
+    html
+  else
+    html = html_tag
+  end
+
+  html.html_safe
+end

--- a/config/initializers/custom_form_errors.rb
+++ b/config/initializers/custom_form_errors.rb
@@ -3,6 +3,8 @@ ActionView::Base.field_error_proc = proc do |html_tag, instance|
   field = fragment.at('input,select,textarea')
   error_messages = instance.object.errors.messages
 
+  debugger
+
   html = nil
   if field
     field['class'] = "#{field['class']} invalid"


### PR DESCRIPTION
Updated the form-floating input styles so error messages are better displayed.
Having some issues getting the checkbox for terms and conditions to highlight when not checked, but without re-writing the field_error_proc there's no easy way to achieve this.
Before:
<img width="899" alt="Screenshot 2021-11-11 at 11 18 24" src="https://user-images.githubusercontent.com/24230549/141289291-e93e0f76-e0c3-44c7-b4d0-97df10a11516.png">

After:
<img width="937" alt="Screenshot 2021-11-11 at 11 09 38" src="https://user-images.githubusercontent.com/24230549/141289284-ae4bb196-ad19-4180-bdcb-7a9d409f64b1.png">
