### PR TITLE
Removed reference to current page from param object

### DIFF
--- a/app/views/shared/search/_pagination_controls.html.erb
+++ b/app/views/shared/search/_pagination_controls.html.erb
@@ -2,8 +2,9 @@
   <div class="container">
     <div class="row">
       <div class="col">
+        <% params.delete :page%>
         <% unless @page == 1 %>
-          <%= link_to send("#{index}_path", page: @page - 1, params: params.permit(Pagination.permitted_params)),
+          <%=  link_to send("#{index}_path", page: @page - 1, params: params.permit(Pagination.permitted_params)),
                       class: 'btn btn-primary' do %>
             <i class="fas fa-arrow-circle-left"></i> Previous
           <% end %>
@@ -27,7 +28,7 @@
             <% unless @page + 1 == @last_page - 1 %> ... <% end %>
           <% end %>
 
-          <%= link_to @last_page, send("#{index}_path", page: @last_page, params: params.permit(Pagination.permitted_params)) %>
+          <%= link_to @last_page, send("#{index}_path",  page: @last_page, params: params.permit(Pagination.permitted_params)) %>
         <% end %>
       </div>
       <div class="col">

--- a/app/views/shared/search/_pagination_controls.html.erb
+++ b/app/views/shared/search/_pagination_controls.html.erb
@@ -4,7 +4,7 @@
       <div class="col">
         <% params.delete :page%>
         <% unless @page == 1 %>
-          <%=  link_to send("#{index}_path", page: @page - 1, params: params.permit(Pagination.permitted_params)),
+          <%= link_to send("#{index}_path", page: @page - 1, params: params.permit(Pagination.permitted_params)),
                       class: 'btn btn-primary' do %>
             <i class="fas fa-arrow-circle-left"></i> Previous
           <% end %>
@@ -28,7 +28,7 @@
             <% unless @page + 1 == @last_page - 1 %> ... <% end %>
           <% end %>
 
-          <%= link_to @last_page, send("#{index}_path",  page: @last_page, params: params.permit(Pagination.permitted_params)) %>
+          <%= link_to @last_page, send("#{index}_path", page: @last_page, params: params.permit(Pagination.permitted_params)) %>
         <% end %>
       </div>
       <div class="col">


### PR DESCRIPTION
The problem was that send() was lexiographically ordering the pages, and the parameters would always have the page you were on as one parameter (because it was preserving the params in order to also save the feeling filters etc)

So if the latest page you visited started with a higher number, you couldn't then navigate to a page with a lower starting number

One solution may be to override the default behavior, but for now we can just remove the current page from the param object
