### PR TITLE
IJ-318: set allowable upload size

### DIFF
--- a/app/controllers/team_members/notifications_controller.rb
+++ b/app/controllers/team_members/notifications_controller.rb
@@ -4,7 +4,7 @@ module TeamMembers
     before_action :set_breadcrumbs
 
     def index
-      @notifications = current_team_member.notifications.where(viewed: false)
+      @notifications = current_team_member.notifications.where(viewed: false, upload_id: nil)
     end
 
     def update

--- a/app/controllers/team_members/uploads_controller.rb
+++ b/app/controllers/team_members/uploads_controller.rb
@@ -31,7 +31,7 @@ module TeamMembers
       @upload_file = new_upload_file
       @upload_file.upload = @upload
 
-      max_file_size = 250.megabytes
+      max_file_size = 5.megabytes
       if @upload_file.data.size > max_file_size
         flash[:error] = 'File size exceeds the maximum limit of 250MB.'
         render 'new', status: :unprocessable_entity

--- a/app/controllers/team_members/uploads_controller.rb
+++ b/app/controllers/team_members/uploads_controller.rb
@@ -32,8 +32,13 @@ module TeamMembers
       @upload_file.upload = @upload
 
       max_file_size = 5.megabytes
+      total_max_file_size = 250.megabytes
       if @upload_file.data.size > max_file_size
-        flash[:error] = 'File size exceeds the maximum limit of 250MB.'
+        flash[:error] = 'File size exceeds the maximum limit of 5MB.'
+        render 'new', status: :unprocessable_entity
+        return
+      elsif current_team_member.total_upload_size >= total_max_file_size
+        flash[:error] = 'Total file size exceeds the maximum limit of 250MB.'
         render 'new', status: :unprocessable_entity
         return
       end

--- a/app/controllers/team_members/uploads_controller.rb
+++ b/app/controllers/team_members/uploads_controller.rb
@@ -217,8 +217,8 @@ module TeamMembers
     end
 
     def check_file_size
-      max_file_size = 5.megabytes
-      total_max_file_size = 250.megabytes
+      max_file_size = ENV['MAX_FILE_SIZE']
+      total_max_file_size = ENV['TOTAL_MAX_FILE_SIZE']
       if @upload_file.data.size > max_file_size
         'exceeds individual file size'
       elsif current_team_member.total_upload_size + @upload_file.data.size >= total_max_file_size

--- a/app/controllers/team_members/uploads_controller.rb
+++ b/app/controllers/team_members/uploads_controller.rb
@@ -37,7 +37,7 @@ module TeamMembers
         flash[:error] = 'File size exceeds the maximum limit of 5MB.'
         render 'new', status: :unprocessable_entity
         return
-      elsif current_team_member.total_upload_size >= total_max_file_size
+      elsif current_team_member.total_upload_size + @upload_file.data.size >= total_max_file_size
         flash[:error] = 'Total file size exceeds the maximum limit of 250MB.'
         render 'new', status: :unprocessable_entity
         return
@@ -106,12 +106,10 @@ module TeamMembers
     end
 
     def destroy
-      return unless @upload.added_by_id == current_team_member.id
-
       action = params[:reject] == 'true' ? 'rejected' : 'deleted'
       handle_delete_upload_log(action)
       if @upload.destroy
-        decrease_total_upload_size(action, current_team_member, @user, @upload_file.data.size)
+        decrease_total_upload_size(action, current_team_member, @user, @upload.upload_file.data.size)
         flash[:notice] = "Upload was #{action} successfully!"
         redirect_to user_uploads_path
       else

--- a/app/controllers/team_members/uploads_controller.rb
+++ b/app/controllers/team_members/uploads_controller.rb
@@ -26,11 +26,11 @@ module TeamMembers
       @upload_notification.upload = @upload if upload_params[:visible_to_user] == 1
 
       if check_file_size == 'exceeds individual file size'
-        flash[:error] = 'File size exceeds the maximum limit of 5MB'
+        flash[:error] = "File size exceeds the maximum limit of #{eval(ENV['MAX_FILE_SIZE'])}"
         render 'new', status: :unprocessable_entity
       elsif check_file_size == 'exceeds total file size per person'
-        flash[:error] = 'Your overall file usage has gone beyond the allocated limit of 250MB per person.
-                         It\'s recommended to create space by removing older files.'
+        flash[:error] = "Your overall file usage has gone beyond the allocated limit of #{eval(ENV['TOTAL_MAX_FILE_SIZE'])} per person.
+                         It\'s recommended to create space by removing older files."
         render 'new', status: :unprocessable_entity
       elsif @upload.save && @upload_file.save && (@upload_notification.nil? || @upload_notification.save)
         current_team_member.increment!(:total_upload_size, @upload_file.data.size)

--- a/app/controllers/team_members/uploads_controller.rb
+++ b/app/controllers/team_members/uploads_controller.rb
@@ -70,16 +70,16 @@ module TeamMembers
 
     def download_file
       @upload_file = @upload.upload_file
-      pdf_blob = @upload_file.data
+      file_blob = @upload_file.data
       log_uploads_activity('downloaded') if @upload.added_by == 'User'
 
       case @upload_file.content_type
       when 'application/pdf'
-        send_data pdf_blob, filename: @upload_file.name, type: 'application/pdf', disposition: 'attachment'
+        send_data file_blob, filename: @upload_file.name, type: 'application/pdf', disposition: 'attachment'
       when 'image/jpeg'
-        send_data pdf_blob, filename: @upload_file.name, type: 'image/jpeg', disposition: 'attachment'
+        send_data file_blob, filename: @upload_file.name, type: 'image/jpeg', disposition: 'attachment'
       when 'image/png'
-        send_data pdf_blob, filename: @upload_file.name, type: 'image/png', disposition: 'attachment'
+        send_data file_blob, filename: @upload_file.name, type: 'image/png', disposition: 'attachment'
       end
     end
 

--- a/app/controllers/users/uploads_controller.rb
+++ b/app/controllers/users/uploads_controller.rb
@@ -18,11 +18,11 @@ module Users
       @upload_file.upload = @upload
 
       if check_file_size == 'exceeds individual file size'
-        flash[:error] = 'File size exceeds the maximum limit of 5MB'
+        flash[:error] = "File size exceeds the maximum limit of #{eval(ENV['MAX_FILE_SIZE'])}"
         render 'new', status: :unprocessable_entity
       elsif check_file_size == 'exceeds total file size per person'
-        flash[:error] = 'Your overall file usage has gone beyond the allocated limit of 250MB per person.
-                         It\'s recommended to create space by removing older files.'
+        flash[:error] = "Your overall file usage has gone beyond the allocated limit of #{eval(ENV['TOTAL_MAX_FILE_SIZE'])} per person.
+                         It\'s recommended to create space by removing older files."
         render 'new', status: :unprocessable_entity
       elsif @upload.save && @upload_file.save && (@upload_notification.nil? || @upload_notification.save)
         email_team_members_about_upload(current_user, @upload_file)

--- a/app/controllers/users/uploads_controller.rb
+++ b/app/controllers/users/uploads_controller.rb
@@ -167,8 +167,8 @@ module Users
     end
 
     def check_file_size
-      max_file_size = 5.megabytes
-      total_max_file_size = 250.megabytes
+      max_file_size = ENV['MAX_FILE_SIZE']
+      total_max_file_size = ENV['TOTAL_MAX_FILE_SIZE']
       if @upload_file.data.size > max_file_size
         'exceeds individual file size'
       elsif current_user.total_upload_size + @upload_file.data.size >= total_max_file_size

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,6 +1,6 @@
 # app/helpers/notifications_helper.rb
 module NotificationsHelper
   def alert_user_of_notifications?
-    current_team_member && current_team_member.notifications.where(viewed: false).count.positive?
+    current_team_member && current_team_member.notifications.where(viewed: false, upload_id: nil).count.positive?
   end
 end

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -21,4 +21,8 @@ module UploadsHelper
   def current_user_visible_uploads
     current_user.uploads.where(visible_to_user: true)
   end
+
+  def bytes_to_megabytes(bytes)
+    (bytes.to_f / 1_048_576).round(2) # Convert bytes to MB and round to two decimal places
+  end
 end

--- a/app/javascript/packs/uploads.js
+++ b/app/javascript/packs/uploads.js
@@ -119,7 +119,7 @@ function handleUpload(event) {
 async function processFile(file) {
     try {
       // Check the file size
-      const maxFileSize = 250 * 1024 * 1024;
+      const maxFileSize = 5 * 1024 * 1024;
       if (file.size > maxFileSize) {
         file_error_handler();
         return;

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,6 +1,7 @@
 class Notification < ApplicationRecord
   belongs_to :team_member
   belongs_to :user
+  belongs_to :upload, optional: true
 
 
   def self.create_for_all_teammembers

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,8 +1,7 @@
 class Notification < ApplicationRecord
-  belongs_to :team_member
-  belongs_to :user
+  belongs_to :team_member, optional: true
+  belongs_to :user, optional: true
   belongs_to :upload, optional: true
-
 
   def self.create_for_all_teammembers
     TeamMember.find_each do |team_member|
@@ -11,24 +10,23 @@ class Notification < ApplicationRecord
       end
     end
   end
-  
+
   def self.create_user_notification(team_member, user)
     if user.created_at.to_date == 6.months.ago.to_date || should_create_notification?(user)
       Notification.create!(
         team_member: team_member,
-        message: "Please check the accommodation status for:",
+        message: 'Please check the accommodation status for:',
         user: user
       )
     end
   end
-  
+
   def self.should_create_notification?(user)
     user_notifications = Notification.where(
       user_id: user.id,
-      message: "Please check the accommodation status for:"
+      message: 'Please check the accommodation status for:'
     )
-  
+
     user.created_at.to_date < 6.months.ago.to_date && (user_notifications.empty? || user_notifications.last.created_at.to_date == 6.months.ago.to_date)
   end
-  
 end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -38,6 +38,7 @@ class TeamMember < DeviseRecord
   validates_presence_of :first_name, :last_name, :mobile_number, :email, :terms
   validates :email, uniqueness: { case_sensitive: false }
   validates :terms, acceptance: true
+  validates :total_upload_size, numericality: { greater_than_or_equal_to: 0 }
   validates_format_of :first_name, :last_name, with: Rails.application.config.regex_name,
                                                message: Rails.application.config.name_error
   validates_format_of :mobile_number, with: Rails.application.config.regex_telephone,

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -6,6 +6,7 @@ class Upload < ApplicationRecord
   belongs_to :team_member, optional: true
   has_one :upload_file, dependent: :destroy
   has_many :upload_activity_logs
+  has_one :notification
 
   validates_presence_of :status
   validates :status, inclusion: { in: %w[pending approved] }

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -10,6 +10,7 @@ class Upload < ApplicationRecord
   validates_presence_of :status
   validates :status, inclusion: { in: %w[pending approved] }
   validates :added_by, inclusion: { in: %w[User TeamMember] }
+  validates_associated :upload_file
   validates_format_of :comment, with: Rails.application.config.regex_text_field,
                                 message: Rails.application.config.text_field_error
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,6 +102,7 @@ class User < DeviseRecord
   validates :sex, inclusion: { in: SEX_OPTIONS }
   validates :gender_identity, inclusion: { in: GENDER_IDENTITY_OPTIONS }
   validates :pronouns, inclusion: { in: PRONOUN_OPTIONS }
+  validates :total_upload_size, numericality: { greater_than_or_equal_to: 0 }
 
   def dob
     date_of_birth.present? ? date_of_birth.strftime('%d/%m/%Y') : ''

--- a/app/views/layouts/_searchable.erb
+++ b/app/views/layouts/_searchable.erb
@@ -30,6 +30,14 @@
           </div>
         <% end %>
 
+        <div class="my-2">
+          <% if params[:controller]  == 'users/uploads' %>
+            You have used <%= bytes_to_megabytes(current_user.total_upload_size)%>MB out of 250MB.
+          <% elsif params[:controller]  == 'team_members/uploads'%>
+            You have used <%= bytes_to_megabytes(current_team_member.total_upload_size)%>MB out of 250MB.
+          <% end %>
+        </div>
+
         <hr />
 
         <div class="row pb-3">

--- a/app/views/shared/uploads/_form.html.erb
+++ b/app/views/shared/uploads/_form.html.erb
@@ -3,7 +3,7 @@
         <div class="row justify-content-center">
             <div class="col-md-6">
                 <div class="mb-1">
-                    <% if @upload.new_record? || current_user.id == @upload.user_id %>
+                    <% if @upload.new_record? || current_user&.id == @upload.added_by_id || current_team_member&.id == @upload.added_by_id %>
                         <div id="file-drag-div" draggable="true">
                             <div id="file-holder" class="file-display text-center">
                                 <% if @upload_file.data.present? %>
@@ -22,13 +22,23 @@
                         <p id="file-error" class="text-capitalize text-danger"></p>
                     <% end %>
                 </div>
-                <div class="form-floating mb-3">
-                    <%= form.text_field :name, class: 'form-control', id: 'upload_name' %>
-                    <%= form.label :name, "Name" %>
+                <div id="form-name-section" class="mb-3">
+                    <div class="form-floating">
+                        <%= form.text_field :name, class: 'form-control', id: 'upload_name' %>
+                        <%= form.label :name, "Name" %>
+                    </div>
+                    <% if @upload_file.errors[:name].any? %>
+                        <p class="text-danger"><%= @upload_file.errors[:name].join(', ') %></p>
+                    <% end %>
                 </div>
-                <div class="form-floating mb-3">
-                    <%= form.text_area :comment, class: 'form-control', oninput:'this.style.height = ""; this.style.height = this.scrollHeight + "px"' %>
-                    <%= form.label "Comment" %>
+                <div id="form-comment-section" class="mb-3">
+                    <div class="form-floating">
+                        <%= form.text_area :comment, class: 'form-control', oninput:'this.style.height = ""; this.style.height = this.scrollHeight + "px"' %>
+                        <%= form.label "Comment" %>
+                    </div>
+                    <% if @upload.errors[:comment].any? %>
+                        <p class="text-danger"><%= @upload.errors[:comment].join(', ') %></p>
+                    <% end %>
                 </div>
                 <div class="form-check form-switch d-flex justify-content-between px-0 pb-3 <%="d-none" if current_user %>">
                     <%= form.label :visible_to_user, class: 'form-check-label text-light' do %>
@@ -38,12 +48,7 @@
                 </div>
 
                 <div class="text-center mb-3 ">
-                <% if @upload.new_record? %>
                     <%= form.submit "Submit", class: 'btn btn-primary', data: {turbo: false} %>
-                <% else %>
-                    <%= form.submit "Save", class: 'btn btn-primary me-2' %>
-                    <%= link_to "Cancel", upload_path(@upload), class: 'btn btn-warning'%>
-                <% end %>
                 <div>
             </div>
         </div>

--- a/app/views/shared/uploads/_show.html.erb
+++ b/app/views/shared/uploads/_show.html.erb
@@ -167,7 +167,7 @@
                 </div> 
               <% elsif (current_team_member && @upload.added_by == 'User') %> 
                 <div class="button-flex-item">
-                  <%= link_to download_file_user_upload_path(@upload), target: '_blank', class: 'btn btn-primary w-100 mb-1' do %>
+                  <%= link_to download_file_user_upload_path(id: @upload.id, user_id: @user.id), target: '_blank', class: 'btn btn-primary w-100 mb-1' do %>
                     <i class="fas fa-download"></i> Download
                   <% end %>
                 </div>

--- a/db/migrate/20230809164456_create_notifications.rb
+++ b/db/migrate/20230809164456_create_notifications.rb
@@ -1,7 +1,7 @@
 class CreateNotifications < ActiveRecord::Migration[6.1]
   def change
     create_table :notifications do |t|
-      t.references :team_member, null: false, foreign_key: true
+      t.references :team_member, null: true, foreign_key: true
       t.references :user, null: true, foreign_key: true
       t.text :message
       t.boolean :viewed, default: false

--- a/db/migrate/20230811145917_add_total_upload_size.rb
+++ b/db/migrate/20230811145917_add_total_upload_size.rb
@@ -1,0 +1,6 @@
+class AddTotalUploadSize < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :total_upload_size, :integer, default: 0
+    add_column :team_members, :total_upload_size, :integer, default: 0
+  end
+end

--- a/db/migrate/20230821124617_add_upload_to_notification.rb
+++ b/db/migrate/20230821124617_add_upload_to_notification.rb
@@ -1,0 +1,5 @@
+class AddUploadToNotification < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :notifications, :upload, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -201,7 +201,7 @@ ActiveRecord::Schema.define(version: 2023_08_21_124617) do
   end
 
   create_table "notifications", force: :cascade do |t|
-    t.bigint "team_member_id", null: false
+    t.bigint "team_member_id"
     t.bigint "user_id"
     t.text "message"
     t.boolean "viewed", default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_03_111932) do
+ActiveRecord::Schema.define(version: 2023_08_11_145917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -165,11 +165,12 @@ ActiveRecord::Schema.define(version: 2023_08_03_111932) do
   create_table "messages", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "team_member_id", null: false
-    t.integer "note_id"
+    t.bigint "note_id", null: false
     t.boolean "read", default: false
     t.string "message_status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["note_id"], name: "index_messages_on_note_id"
     t.index ["team_member_id"], name: "index_messages_on_team_member_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
@@ -324,6 +325,7 @@ ActiveRecord::Schema.define(version: 2023_08_03_111932) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
+    t.integer "total_upload_size", default: 0
     t.index ["confirmation_token"], name: "index_team_members_on_confirmation_token", unique: true
     t.index ["email"], name: "index_team_members_on_email", unique: true
     t.index ["reset_password_token"], name: "index_team_members_on_reset_password_token", unique: true
@@ -476,6 +478,7 @@ ActiveRecord::Schema.define(version: 2023_08_03_111932) do
     t.boolean "suspended", default: false
     t.datetime "suspended_at"
     t.text "summary_panel"
+    t.integer "total_upload_size", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_11_145917) do
+ActiveRecord::Schema.define(version: 2023_08_21_124617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -207,7 +207,9 @@ ActiveRecord::Schema.define(version: 2023_08_11_145917) do
     t.boolean "viewed", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "upload_id"
     t.index ["team_member_id"], name: "index_notifications_on_team_member_id"
+    t.index ["upload_id"], name: "index_notifications_on_upload_id"
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 
@@ -579,6 +581,7 @@ ActiveRecord::Schema.define(version: 2023_08_11_145917) do
   add_foreign_key "notes", "team_members"
   add_foreign_key "notes", "users"
   add_foreign_key "notifications", "team_members"
+  add_foreign_key "notifications", "uploads"
   add_foreign_key "notifications", "users"
   add_foreign_key "sessions", "users"
   add_foreign_key "survey_answers", "survey_questions"


### PR DESCRIPTION
- Allot 5MB for each individual file.
- Set a cap of 250MB for the total file storage per person.
- Let people see how much space they have used.
- Creates a notification for users, when team members add files that they can see.
- Fix bugs and refactor code.


Fufils this ticket: https://lilw.atlassian.net/browse/IJ-318