### PR TITLE
IJ-212: Notification for team members to perform check on users

### DIFF
--- a/app/controllers/team_members/notifications_controller.rb
+++ b/app/controllers/team_members/notifications_controller.rb
@@ -14,6 +14,13 @@ module TeamMembers
       redirect_to notifications_path
     end
 
+    def update_notification_frequency
+      team_member_notification_frequency = current_team_member.team_member_notification_frequency
+      attribute_to_update = params[:check_up_type].to_sym
+      team_member_notification_frequency.update!(attribute_to_update => "#{params[:frequency]} #{params[:time_unit]}")
+      redirect_to notifications_path, notice: 'Notification frequency updated successfully.'
+    end
+
     private
 
     def update_notifications_to_read

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -33,10 +33,10 @@ class Notification < ApplicationRecord
   end
 
   def self.notification_frequency(team_member)
-    accommodation_status_freqency = team_member.team_member_notification_frequency.accommodation_status.to_i
-    wellbeing_assessment_frequency = team_member.team_member_notification_frequency.wellbeing_assessment.to_i
-    { accommodation_status: accommodation_status_freqency.months.ago.to_date,
-      wellbeing_assessment: wellbeing_assessment_frequency.months.ago.to_date }
+    accommodation_status_freqency = team_member.team_member_notification_frequency.accommodation_status
+    wellbeing_assessment_frequency = team_member.team_member_notification_frequency.wellbeing_assessment
+    { accommodation_status: convert_to_duration(accommodation_status_freqency).ago.to_date,
+      wellbeing_assessment: convert_to_duration(wellbeing_assessment_frequency).ago.to_date }
   end
 
   def self.notification_message
@@ -44,5 +44,16 @@ class Notification < ApplicationRecord
       accommodation_status: 'Please check the accommodation status for:',
       wellbeing_assessment: 'Please perform wellbeing assessment for:'
     }
+  end
+
+  def self.convert_to_duration(duration)
+    quantity, unit = duration.split(' ')
+    quantity = quantity.to_i
+    unit = unit.singularize
+    unit_to_method = { 'second' => :seconds, 'minute' => :minutes, 'hour' => :hours,
+                       'day' => :days, 'week' => :weeks, 'month' => :months, 'year' => :years }
+
+    duration_method = unit_to_method[unit] || :seconds
+    quantity.send(duration_method)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,7 +1,25 @@
+# app/models/notification.rb
 class Notification < ApplicationRecord
   belongs_to :team_member, optional: true
   belongs_to :user, optional: true
   belongs_to :upload, optional: true
+
+  CHECKUP_TYPES = [
+    'accommodation_status',
+    'wellbeing_assessment',
+    nil
+  ].freeze
+
+  TIME_UNITS = [
+    'seconds',
+    'minutes',
+    'hours',
+    'days',
+    'weeks',
+    'months',
+    'years',
+    nil
+  ].freeze
 
   def self.create_for_all_teammembers
     TeamMember.find_each do |team_member|

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -30,6 +30,7 @@ class TeamMember < DeviseRecord
   has_many :notifications
   has_many :uploads
   has_many :upload_activity_logs
+  has_one :team_member_notification_frequency
 
   scope :approved, -> { where(approved: true) }
   scope :unapproved, -> { where(approved: false) }

--- a/app/models/team_member_notification_frequency.rb
+++ b/app/models/team_member_notification_frequency.rb
@@ -1,0 +1,3 @@
+class TeamMemberNotificationFrequency < ApplicationRecord
+  belongs_to :team_member
+end

--- a/app/views/team_members/notifications/_edit_frequency.html.erb
+++ b/app/views/team_members/notifications/_edit_frequency.html.erb
@@ -1,0 +1,22 @@
+<div class="col-12 col-md-7">
+    <div class="form-container">
+        <%= form_with(url: edit_notification_frequency_path, method: :put) do |form| %>
+            <div class="field">
+                <%= form.label :check_up_type, 'Check-up Type' %>
+                <%= form.select :check_up_type, ['accommodation_status', 'wellbeing_assessment'] %>
+            </div>
+
+            <div class="field">
+                <%= form.label :frequency, 'Frequency' %>
+                <%= form.number_field :frequency, min: 1 %>
+            </div>
+
+            <div class="field">
+                <%= form.label :time_unit, 'Time Unit' %>
+                <%= form.select :time_unit, ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years'] %>
+            </div>
+
+            <%= form.submit 'Update' %>
+        <% end %>
+    </div>
+</div>

--- a/app/views/team_members/notifications/_edit_frequency.html.erb
+++ b/app/views/team_members/notifications/_edit_frequency.html.erb
@@ -1,22 +1,41 @@
-<div class="col-12 col-md-7">
-    <div class="form-container">
+<div class="col-12 col-md-7 my-5">
+    <div class="container">
+        <h3 class='text-white'>Notification Settings</h3>
         <%= form_with(url: edit_notification_frequency_path, method: :put) do |form| %>
-            <div class="field">
-                <%= form.label :check_up_type, 'Check-up Type' %>
-                <%= form.select :check_up_type, Notification::CHECKUP_TYPES[0..Notification::CHECKUP_TYPES.count-2], {} %>
+            <div class="row mt-3">
+                <div class="col-md">
+                    <div class="form-floating">
+                        <%= form.select :check_up_type, Notification::CHECKUP_TYPES[0..Notification::CHECKUP_TYPES.count-2], {}, class: 'form-control'%>
+                        <%= form.label :check_up_type, 'Check-up Type'%>
+                    </div>
+                </div>
             </div>
 
-            <div class="field">
-                <%= form.label :frequency, 'Frequency' %>
-                <%= form.number_field :frequency, min: 1, value: 1 %>
+           <div class="row mt-2">
+                <div class="col-md">
+                    <div class="form-floating">
+                        <%= form.number_field :frequency, min: 1, value: 1, class: 'form-control' %>
+                        <%= form.label :frequency, 'Frequency' %>
+                    </div>
+                </div>
             </div>
 
-            <div class="field">
-                <%= form.label :time_unit, 'Time Unit' %>
-                <%= form.select :time_unit, Notification::TIME_UNITS[0..Notification::TIME_UNITS.count-2], {}%>
+            <div class="row mt-2">
+                <div class="col-md">
+                    <div class="form-floating">
+                        <%= form.select :time_unit, Notification::TIME_UNITS[0..Notification::TIME_UNITS.count-2], {}, class: 'form-control'%>
+                        <%= form.label :time_unit, 'Time Unit' %>
+                    </div>
+                </div>
             </div>
-
-            <%= form.submit 'Update' %>
+            
+            <div class="row mt-3">
+                <div class="col-md">
+                    <div class="form-floating">
+                        <%= form.submit 'Update', class: 'btn btn-primary w-100' %>
+                    </div>
+                </div>
+            </div>
         <% end %>
     </div>
 </div>

--- a/app/views/team_members/notifications/_edit_frequency.html.erb
+++ b/app/views/team_members/notifications/_edit_frequency.html.erb
@@ -3,17 +3,17 @@
         <%= form_with(url: edit_notification_frequency_path, method: :put) do |form| %>
             <div class="field">
                 <%= form.label :check_up_type, 'Check-up Type' %>
-                <%= form.select :check_up_type, ['accommodation_status', 'wellbeing_assessment'] %>
+                <%= form.select :check_up_type, Notification::CHECKUP_TYPES[0..Notification::CHECKUP_TYPES.count-2], {} %>
             </div>
 
             <div class="field">
                 <%= form.label :frequency, 'Frequency' %>
-                <%= form.number_field :frequency, min: 1 %>
+                <%= form.number_field :frequency, min: 1, value: 1 %>
             </div>
 
             <div class="field">
                 <%= form.label :time_unit, 'Time Unit' %>
-                <%= form.select :time_unit, ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years'] %>
+                <%= form.select :time_unit, Notification::TIME_UNITS[0..Notification::TIME_UNITS.count-2], {}%>
             </div>
 
             <%= form.submit 'Update' %>

--- a/app/views/team_members/notifications/index.html.erb
+++ b/app/views/team_members/notifications/index.html.erb
@@ -1,11 +1,11 @@
 <main class="container users appointments">
   <div class="">
     <div class="h-100">
+      <%= render partial: 'edit_frequency'%>
+
       <div class="card-header">
         <h3 class="text-white">All Notifications</h3>
       </div>
-
-      <%= render partial: 'edit_frequency'%>
 
       <div class="" id="notes-card">
         <% if @notifications.empty? %>

--- a/app/views/team_members/notifications/index.html.erb
+++ b/app/views/team_members/notifications/index.html.erb
@@ -4,20 +4,23 @@
       <div class="card-header">
         <h3 class="text-white">All Notifications</h3>
       </div>
-        <div class="" id="notes-card">
-          <% if @notifications.empty? %>
-            <div class="card my-2 note-card">
-              <div class="card-body ">
-                <span> You have no new notifications. </span>
-              </div>
+
+      <%= render partial: 'edit_frequency'%>
+
+      <div class="" id="notes-card">
+        <% if @notifications.empty? %>
+          <div class="card my-2 note-card">
+            <div class="card-body ">
+              <span> You have no new notifications. </span>
             </div>
-          <% else %>
-           <% @notifications.all.each do |notification| %>
-              <% if !notification.viewed?%>
-                <%= render 'team_members/notifications/card', message: notification%>
-              <% end %> 
-            <% end %>
+          </div>
+        <% else %>
+          <% @notifications.all.each do |notification| %>
+            <% if !notification.viewed?%>
+              <%= render 'team_members/notifications/card', message: notification%>
+            <% end %> 
           <% end %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,11 +167,8 @@ Rails.application.routes.draw do
           resources :survey_responses, only: %i[index show], param: :response_id, as: :survey_response
         end
       end
-      resources :notifications do
-        member do
-          put 'edit_notification_frequency', to: 'notifications#update_notification_frequency'
-        end
-      end
+      resources :notifications
+      put 'edit_notification_frequency', to: 'notifications#update_notification_frequency', as: :edit_notification_frequency
     end
     get '/*path', to: redirect('')
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,7 +167,11 @@ Rails.application.routes.draw do
           resources :survey_responses, only: %i[index show], param: :response_id, as: :survey_response
         end
       end
-      resources :notifications
+      resources :notifications do
+        member do
+          put 'edit_notification_frequency', to: 'notifications#update_notification_frequency'
+        end
+      end
     end
     get '/*path', to: redirect('')
   end

--- a/db/migrate/20231016193215_create_team_member_notification_frequency.rb
+++ b/db/migrate/20231016193215_create_team_member_notification_frequency.rb
@@ -1,0 +1,11 @@
+class CreateTeamMemberNotificationFrequency < ActiveRecord::Migration[6.1]
+  def change
+    create_table :team_member_notification_frequencies do |t|
+      t.string :accommodation_status, default: '6 months'
+      t.string :wellbeing_assessment, default: '3 months'
+      t.references :team_member, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231016193215_create_team_member_notification_frequency.rb
+++ b/db/migrate/20231016193215_create_team_member_notification_frequency.rb
@@ -3,7 +3,6 @@ class CreateTeamMemberNotificationFrequency < ActiveRecord::Migration[6.1]
     create_table :team_member_notification_frequencies do |t|
       t.string :accommodation_status, default: '6 months'
       t.string :wellbeing_assessment, default: '3 months'
-      t.references :team_member, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20231017024106_add_team_member_references_to_team_member_notification_frequency.rb
+++ b/db/migrate/20231017024106_add_team_member_references_to_team_member_notification_frequency.rb
@@ -1,0 +1,7 @@
+class AddTeamMemberReferencesToTeamMemberNotificationFrequency < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :team_member_notification_frequencies, :team_member, null: false, foreign_key: true
+
+    TeamMember.find_each(&:create_team_member_notification_frequency)
+  end
+end


### PR DESCRIPTION
I allowed the team member to edit their notification frequency for different checkup types.

There are currently two check-up types now the code is written so that it is scalable to allow more checkup types in the future.

This fulfils this ticket: [Ticket 1J-212](https://lilw.atlassian.net/browse/IJ-212)